### PR TITLE
Remove multiple runtimes support from API

### DIFF
--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -142,32 +142,26 @@ fn generate_new_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStr
         let settings_field_identifier = service_settings_field_identifier_from(field_identifier);
         quote! {
             #field_identifier: {
-                let (runtime, manager) =
+                let manager =
                     ::overwatch::services::handle::ServiceHandle::<#service_type>::new(
                         #settings_field_identifier, overwatch_handle.clone(),
                 );
-                runtimes.insert(<#service_type as ::overwatch::services::ServiceData>::SERVICE_ID, runtime);
                 manager
             }
         }
     });
 
     quote! {
-        fn new(settings: Self::Settings, overwatch_handle: ::overwatch::overwatch::handle::OverwatchHandle) -> (
-            std::collections::HashMap<::overwatch::services::ServiceId, ::std::option::Option<::tokio::runtime::Runtime>>,
-            Self
-        ) {
+        fn new(settings: Self::Settings, overwatch_handle: ::overwatch::overwatch::handle::OverwatchHandle) -> Self {
             let Self::Settings {
                 #( #fields_settings ),*
             } = settings;
-
-            let mut runtimes = ::std::collections::HashMap::new();
 
             let app = Self {
                 #( #managers ),*
             };
 
-            (runtimes, app)
+            app
         }
     }
 }

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -45,18 +45,6 @@ pub trait ServiceCore: ServiceData + Send + Sized + 'static {
     /// Initialize the service with the given state
     fn init(service_state: ServiceStateHandle<Self>) -> Self;
 
-    /// Service default runtime
-    fn service_runtime(_settings: &Self::Settings, _parent: &runtime::Handle) -> ServiceRuntime {
-        let id = Self::SERVICE_ID;
-        ServiceRuntime::Custom(
-            runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_name(id)
-                .build()
-                .unwrap_or_else(|_| panic!("Async runtime for service {id} didn't build properly")),
-        )
-    }
-
     /// Service main loop
     async fn run(mut self);
 }


### PR DESCRIPTION
Having multiple runtime coexist is suboptimal from a performance point of view and may even result in unnecessary dependencies on the specific runtime used.
If extreme control is needed on how a service is executed in addition to what is already provided by the single existing runtime, it's advisable to spawn a new thread and do the customization there.