### PR TITLE
Use awaiting connect for services relay

### DIFF
--- a/examples/waku-chat/src/network/mod.rs
+++ b/examples/waku-chat/src/network/mod.rs
@@ -63,7 +63,7 @@ impl<I: NetworkBackend + Send + 'static> ServiceCore for NetworkService<I> {
             service_state,
             mut implem,
         } = self;
-        let mut relay = service_state.inbound_relay;
+        let mut relay = service_state.inbound_relay.inner_relay();
 
         while let Some(msg) = relay.recv().await {
             match msg {

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -245,7 +245,6 @@ fn generate_request_relay_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2
                 ::std::result::Result::Ok(::std::boxed::Box::new(
                     self.#field_identifier
                         .relay_with()
-                        .ok_or(::overwatch_rs::services::relay::RelayError::AlreadyConnected)?
                 ) as ::overwatch_rs::services::relay::AnyMessage)
             }
         }

--- a/overwatch-rs/tests/generics.rs
+++ b/overwatch-rs/tests/generics.rs
@@ -50,14 +50,13 @@ where
         use tokio::io::{self, AsyncWriteExt};
 
         let Self {
-            state: ServiceStateHandle {
-                mut inbound_relay, ..
-            },
+            state: ServiceStateHandle { inbound_relay, .. },
             ..
         } = self;
 
         let generic = async move {
             let mut stdout = io::stdout();
+            let mut inbound_relay = inbound_relay.inner_relay();
             while let Some(message) = inbound_relay.recv().await {
                 match message.0.as_ref() {
                     "stop" => {

--- a/overwatch-rs/tests/print_service.rs
+++ b/overwatch-rs/tests/print_service.rs
@@ -36,13 +36,12 @@ impl ServiceCore for PrintService {
         use tokio::io::{self, AsyncWriteExt};
 
         let Self {
-            state: ServiceStateHandle {
-                mut inbound_relay, ..
-            },
+            state: ServiceStateHandle { inbound_relay, .. },
         } = self;
 
         let print = async move {
             let mut stdout = io::stdout();
+            let mut inbound_relay = inbound_relay.inner_relay();
             while let Some(message) = inbound_relay.recv().await {
                 match message.0.as_ref() {
                     "stop" => {

--- a/overwatch-rs/tests/sequence_init.rs
+++ b/overwatch-rs/tests/sequence_init.rs
@@ -1,0 +1,115 @@
+use overwatch_derive::Services;
+use overwatch_rs::overwatch::OverwatchRunner;
+use overwatch_rs::services::handle::{ServiceHandle, ServiceStateHandle};
+use overwatch_rs::services::relay::{NoMessage, Relay};
+use overwatch_rs::services::state::{NoOperator, NoState};
+use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
+use overwatch_rs::DynError;
+use std::time::Duration;
+use tracing::debug;
+
+pub struct AwaitService1 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService2 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService3 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+impl ServiceData for AwaitService1 {
+    const SERVICE_ID: ServiceId = "S1";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService2 {
+    const SERVICE_ID: ServiceId = "S2";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService3 {
+    const SERVICE_ID: ServiceId = "S3";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService1 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        debug!("Initialized 1");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService2 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        let relay: Relay<AwaitService1> = self.service_state.overwatch_handle.relay();
+        relay
+            .connect()
+            .await
+            .expect("Connection from 2 to 1 couldn't be initialized");
+        debug!("Initialized 2");
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService3 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        let relay: Relay<AwaitService2> = self.service_state.overwatch_handle.relay();
+        relay
+            .connect()
+            .await
+            .expect("Connection from 2 to 1 couldn't be initialized");
+        debug!("Initialized 3");
+        Ok(())
+    }
+}
+
+#[derive(Services)]
+struct SequenceServices {
+    c: ServiceHandle<AwaitService3>,
+    b: ServiceHandle<AwaitService2>,
+    a: ServiceHandle<AwaitService1>,
+}
+
+#[test]
+fn run_overwatch_then_shutdown_service_and_kill() {
+    let settings = SequenceServicesServiceSettings {
+        a: (),
+        b: (),
+        c: (),
+    };
+    let overwatch = OverwatchRunner::<SequenceServices>::run(settings, None).unwrap();
+    let handle = overwatch.handle().clone();
+
+    overwatch.spawn(async move {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        handle.shutdown().await;
+    });
+    overwatch.wait_finished();
+}


### PR DESCRIPTION
The idea is to add a mechanism so a service that depends on another service knows when this other one is available. At the moment we stablish a connection between them (A => B) and the the service B replies whenver message arrives, but A has no way of knowing when is this. The firt attemp is to add a signal wrapper around relays (inbound/outbound) that will just return the `OutboundRelay` when the service has been initialize.

This said: The current approach in this PR is not working. Reason is that RelayState wrappers lose messages (state) when clonning, that makes that they may lose the first (and only) signal and keep waiting forever (?)