### PR TITLE
Add mechanism to synchronize and update services status

### DIFF
--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -115,7 +115,9 @@ fn generate_services_impl(
     let impl_start = generate_start_impl(fields);
     let impl_stop = generate_stop_impl(fields);
     let impl_relay = generate_request_relay_impl(fields);
+    let impl_status = generate_request_status_watcher_impl(fields);
     let impl_update_settings = generate_update_settings_impl(fields);
+
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
@@ -131,6 +133,8 @@ fn generate_services_impl(
             #impl_stop
 
             #impl_relay
+
+            #impl_status
 
             #impl_update_settings
         }
@@ -258,6 +262,32 @@ fn generate_request_relay_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2
                 match service_id {
                     #( #cases )*
                     service_id => ::std::result::Result::Err(::overwatch_rs::services::relay::RelayError::Unavailable { service_id })
+                }
+            }
+        }
+    }
+}
+
+fn generate_request_status_watcher_impl(
+    fields: &Punctuated<Field, Comma>,
+) -> proc_macro2::TokenStream {
+    let cases = fields.iter().map(|field| {
+        let field_identifier = field.ident.as_ref().expect("A struct attribute identifier");
+        let type_id = utils::extract_type_from(&field.ty);
+        quote! {
+            <#type_id as ::overwatch_rs::services::ServiceData>::SERVICE_ID => {
+                    ::std::result::Result::Ok(self.#field_identifier.status_watcher())
+            }
+        }
+    });
+
+    quote! {
+        #[::tracing::instrument(skip(self), err)]
+        fn request_status_watcher(&self, service_id: ::overwatch_rs::services::ServiceId) -> ::overwatch_rs::services::status::ServiceStatusResult {
+            {
+                match service_id {
+                    #( #cases )*
+                    service_id => ::std::result::Result::Err(::overwatch_rs::services::status::ServiceStatusError::Unavailable { service_id })
                 }
             }
         }

--- a/overwatch-rs/src/overwatch/commands.rs
+++ b/overwatch-rs/src/overwatch/commands.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 
 // internal
 use crate::services::relay::RelayResult;
+use crate::services::status::StatusWatcher;
 use crate::services::ServiceId;
 
 #[derive(Debug)]
@@ -29,6 +30,13 @@ impl<M> ReplyChannel<M> {
 pub struct RelayCommand {
     pub(crate) service_id: ServiceId,
     pub(crate) reply_channel: ReplyChannel<RelayResult>,
+}
+
+/// Command for requesting
+#[derive(Debug)]
+pub struct StatusCommand {
+    pub(crate) service_id: ServiceId,
+    pub(crate) reply_channel: ReplyChannel<StatusWatcher>,
 }
 
 /// Command for managing [`ServiceCore`](crate::services::ServiceCore) lifecycle
@@ -54,6 +62,7 @@ pub struct SettingsCommand(pub(crate) AnySettings);
 #[derive(Debug)]
 pub enum OverwatchCommand {
     Relay(RelayCommand),
+    Status(StatusCommand),
     ServiceLifeCycle(ServiceLifeCycleCommand),
     OverwatchLifeCycle(OverwatchLifeCycleCommand),
     Settings(SettingsCommand),

--- a/overwatch-rs/src/overwatch/mod.rs
+++ b/overwatch-rs/src/overwatch/mod.rs
@@ -20,12 +20,13 @@ use tracing::{error, info, instrument};
 // internal
 use crate::overwatch::commands::{
     OverwatchCommand, OverwatchLifeCycleCommand, RelayCommand, ServiceLifeCycleCommand,
-    SettingsCommand,
+    SettingsCommand, StatusCommand,
 };
 use crate::overwatch::handle::OverwatchHandle;
 pub use crate::overwatch::life_cycle::ServicesLifeCycleHandle;
 use crate::services::life_cycle::LifecycleMessage;
 use crate::services::relay::RelayResult;
+use crate::services::status::ServiceStatusResult;
 use crate::services::{ServiceError, ServiceId};
 use crate::utils::runtime::default_multithread_runtime;
 
@@ -89,6 +90,8 @@ pub trait Services: Sized {
 
     /// Request communication relay to one of the services
     fn request_relay(&mut self, service_id: ServiceId) -> RelayResult;
+
+    fn request_status_watcher(&self, service_id: ServiceId) -> ServiceStatusResult;
 
     /// Update service settings
     fn update_settings(&mut self, settings: Self::Settings) -> Result<(), Error>;
@@ -165,6 +168,9 @@ where
                 OverwatchCommand::Relay(relay_command) => {
                     Self::handle_relay(&mut services, relay_command).await;
                 }
+                OverwatchCommand::Status(status_command) => {
+                    Self::handle_status(&mut services, status_command).await;
+                }
                 OverwatchCommand::ServiceLifeCycle(msg) => match msg {
                     ServiceLifeCycleCommand {
                         service_id,
@@ -224,10 +230,29 @@ where
         if let Ok(settings) = settings.downcast::<S::Settings>() {
             if let Err(e) = services.update_settings(*settings) {
                 // TODO: add proper logging
-                dbg!(e);
+                error!("{e}");
             }
         } else {
             unreachable!("Statically should always be of the correct type");
+        }
+    }
+    async fn handle_status(
+        services: &mut S,
+        StatusCommand {
+            service_id,
+            reply_channel,
+        }: StatusCommand,
+    ) {
+        let watcher_result = services.request_status_watcher(service_id);
+        match watcher_result {
+            Ok(watcher) => {
+                if reply_channel.reply(watcher).await.is_err() {
+                    error!("Error reporting back status watcher for service: {service_id}")
+                }
+            }
+            Err(e) => {
+                error!("{e}");
+            }
         }
     }
 }
@@ -280,6 +305,7 @@ mod test {
     use crate::overwatch::handle::OverwatchHandle;
     use crate::overwatch::{Error, OverwatchRunner, Services, ServicesLifeCycleHandle};
     use crate::services::relay::{RelayError, RelayResult};
+    use crate::services::status::{ServiceStatusError, ServiceStatusResult};
     use crate::services::ServiceId;
     use std::time::Duration;
     use tokio::time::sleep;
@@ -310,6 +336,10 @@ mod test {
 
         fn request_relay(&mut self, service_id: ServiceId) -> RelayResult {
             Err(RelayError::InvalidRequest { to: service_id })
+        }
+
+        fn request_status_watcher(&self, service_id: ServiceId) -> ServiceStatusResult {
+            Err(ServiceStatusError::Unavailable { service_id })
         }
 
         fn update_settings(&mut self, _settings: Self::Settings) -> Result<(), Error> {

--- a/overwatch-rs/src/services/handle.rs
+++ b/overwatch-rs/src/services/handle.rs
@@ -6,6 +6,7 @@ use crate::services::life_cycle::LifecycleHandle;
 use crate::services::relay::{relay, InboundRelay, OutboundRelay};
 use crate::services::settings::{SettingsNotifier, SettingsUpdater};
 use crate::services::state::{StateHandle, StateOperator, StateUpdater};
+use crate::services::status::{StatusHandle, StatusWatcher};
 use crate::services::{ServiceCore, ServiceData, ServiceId, ServiceState};
 
 // TODO: Abstract handle over state, to differentiate when the service is running and when it is not
@@ -21,6 +22,7 @@ pub struct ServiceHandle<S: ServiceData> {
     /// Handle to overwatch
     overwatch_handle: OverwatchHandle,
     settings: SettingsUpdater<S::Settings>,
+    status: StatusHandle<S>,
     initial_state: S::State,
 }
 
@@ -29,6 +31,7 @@ pub struct ServiceHandle<S: ServiceData> {
 pub struct ServiceStateHandle<S: ServiceData> {
     /// Relay channel to communicate with the service runner
     pub inbound_relay: InboundRelay<S::Message>,
+    pub status_handle: StatusHandle<S>,
     /// Overwatch handle
     pub overwatch_handle: OverwatchHandle,
     pub settings_reader: SettingsNotifier<S::Settings>,
@@ -53,6 +56,7 @@ impl<S: ServiceData> ServiceHandle<S> {
             outbound_relay: None,
             overwatch_handle,
             settings: SettingsUpdater::new(settings),
+            status: StatusHandle::new(),
             initial_state,
         })
     }
@@ -78,6 +82,10 @@ impl<S: ServiceData> ServiceHandle<S> {
         self.outbound_relay.clone()
     }
 
+    pub fn status_watcher(&self) -> StatusWatcher {
+        self.status.watcher()
+    }
+
     /// Update settings
     pub fn update_settings(&self, settings: S::Settings) {
         self.settings.update(settings)
@@ -99,6 +107,7 @@ impl<S: ServiceData> ServiceHandle<S> {
 
         let service_state = ServiceStateHandle {
             inbound_relay,
+            status_handle: self.status.clone(),
             overwatch_handle: self.overwatch_handle.clone(),
             state_updater,
             settings_reader,

--- a/overwatch-rs/src/services/mod.rs
+++ b/overwatch-rs/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod life_cycle;
 pub mod relay;
 pub mod settings;
 pub mod state;
+pub mod status;
 
 // std
 use std::fmt::Debug;

--- a/overwatch-rs/src/services/status.rs
+++ b/overwatch-rs/src/services/status.rs
@@ -4,11 +4,20 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 // crates
-use crate::services::ServiceData;
+use crate::services::{ServiceData, ServiceId};
+use thiserror::Error;
 use tokio::sync::watch;
 // internal
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Error, Debug)]
+pub enum ServiceStatusError {
+    #[error("service {service_id} is not available")]
+    Unavailable { service_id: ServiceId },
+}
+
+pub type ServiceStatusResult = Result<StatusWatcher, ServiceStatusError>;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ServiceStatus {
     Uninitialized,
     Running,
@@ -25,7 +34,7 @@ impl StatusUpdater {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct StatusWatcher(watch::Receiver<ServiceStatus>);
 
 impl StatusWatcher {

--- a/overwatch-rs/src/services/status.rs
+++ b/overwatch-rs/src/services/status.rs
@@ -1,0 +1,77 @@
+// std
+use std::marker::PhantomData;
+use std::time::Duration;
+// crates
+use crate::services::ServiceData;
+use tokio::sync::watch;
+// internal
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum ServiceStatus {
+    Uninitialized,
+    Running,
+    Stopped,
+}
+
+pub struct StatusUpdater(watch::Sender<ServiceStatus>);
+
+impl StatusUpdater {
+    pub fn update(&self, status: ServiceStatus) {
+        self.0
+            .send(status)
+            .expect("Overwatch always maintain an open watcher, send should always succeed")
+    }
+}
+
+#[derive(Clone)]
+pub struct StatusWatcher(watch::Receiver<ServiceStatus>);
+
+impl StatusWatcher {
+    pub async fn wait_for(
+        &mut self,
+        status: ServiceStatus,
+        timeout_duration: Option<Duration>,
+    ) -> Result<ServiceStatus, ServiceStatus> {
+        let current = *self.0.borrow();
+        if status == current {
+            return Ok(current);
+        }
+        let timeout_duration = timeout_duration.unwrap_or_else(|| Duration::from_secs(u64::MAX));
+        tokio::time::timeout(timeout_duration, self.0.wait_for(|s| s == &status))
+            .await
+            .map(|r| r.map(|s| *s).map_err(|_| current))
+            .unwrap_or(Err(current))
+    }
+}
+
+pub struct StatusHandle<S: ServiceData> {
+    updater: StatusUpdater,
+    watcher: StatusWatcher,
+    _phantom: PhantomData<S>,
+}
+
+impl<S: ServiceData> StatusHandle<S> {
+    pub fn new() -> Self {
+        let (updater, watcher) = watch::channel(ServiceStatus::Uninitialized);
+        let updater = StatusUpdater(updater);
+        let watcher = StatusWatcher(watcher);
+        Self {
+            updater,
+            watcher,
+            _phantom: Default::default(),
+        }
+    }
+    pub fn updater(&self) -> &StatusUpdater {
+        &self.updater
+    }
+
+    pub fn watcher(&self) -> StatusWatcher {
+        self.watcher.clone()
+    }
+}
+
+impl<S: ServiceData> Default for StatusHandle<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/overwatch-rs/tests/sequence.rs
+++ b/overwatch-rs/tests/sequence.rs
@@ -1,0 +1,164 @@
+use overwatch_derive::Services;
+use overwatch_rs::overwatch::OverwatchRunner;
+use overwatch_rs::services::handle::{ServiceHandle, ServiceStateHandle};
+use overwatch_rs::services::relay::NoMessage;
+use overwatch_rs::services::state::{NoOperator, NoState};
+use overwatch_rs::services::status::{ServiceStatus, StatusWatcher};
+use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
+use overwatch_rs::DynError;
+use std::time::Duration;
+
+pub struct AwaitService1 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService2 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService3 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+impl ServiceData for AwaitService1 {
+    const SERVICE_ID: ServiceId = "S1";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService2 {
+    const SERVICE_ID: ServiceId = "S2";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService3 {
+    const SERVICE_ID: ServiceId = "S3";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService1 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        println!("Initialized 1");
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService2 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+
+        let mut watcher: StatusWatcher = self
+            .service_state
+            .overwatch_handle
+            .status_watcher::<AwaitService1>()
+            .await;
+
+        watcher
+            .wait_for(ServiceStatus::Running, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+
+        println!("Initialized 2");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        watcher
+            .wait_for(ServiceStatus::Stopped, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService3 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+
+        let mut watcher: StatusWatcher = self
+            .service_state
+            .overwatch_handle
+            .status_watcher::<AwaitService2>()
+            .await;
+
+        watcher
+            .wait_for(ServiceStatus::Running, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+
+        println!("Initialized 3");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        watcher
+            .wait_for(ServiceStatus::Stopped, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[derive(Services)]
+struct SequenceServices {
+    c: ServiceHandle<AwaitService3>,
+    b: ServiceHandle<AwaitService2>,
+    a: ServiceHandle<AwaitService1>,
+}
+
+#[test]
+fn sequenced_services_startup() {
+    let settings = SequenceServicesServiceSettings {
+        a: (),
+        b: (),
+        c: (),
+    };
+    let overwatch = OverwatchRunner::<SequenceServices>::run(settings, None).unwrap();
+    let handle = overwatch.handle().clone();
+
+    overwatch.spawn(async move {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        handle.shutdown().await;
+    });
+    overwatch.wait_finished();
+}


### PR DESCRIPTION
This is a better and simpler approach than #29 . Responsibility is of the services implementations (**With great power comes great responsibility**) to understand the complexities of their services relationships.

## How this works?

There is `tokio::sync::watch` channel handled by the service. Other services can subscribe and get updated requesting a watcher (watch::Receiver) from the calls in the overwatch_handle within services themselves. 
**Service status do not update automatically**, I think is more flexible as service may chose to mark when they are ready to work. Also when they have finished its exection.

`StatusHandle` holds both parts of the sender/receiver parts of the watch channel and its clonable. That way the service can spawn tasks freely and send the handle to handle internal status as well.