### PR TITLE
Add mechanism to synchronize and update services status (Updated from #30)

### DIFF
--- a/overwatch-rs/src/overwatch/commands.rs
+++ b/overwatch-rs/src/overwatch/commands.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 
 // internal
 use crate::services::relay::RelayResult;
+use crate::services::status::StatusWatcher;
 use crate::services::ServiceId;
 
 #[derive(Debug)]
@@ -29,6 +30,13 @@ impl<M> ReplyChannel<M> {
 pub struct RelayCommand {
     pub(crate) service_id: ServiceId,
     pub(crate) reply_channel: ReplyChannel<RelayResult>,
+}
+
+/// Command for requesting
+#[derive(Debug)]
+pub struct StatusCommand {
+    pub(crate) service_id: ServiceId,
+    pub(crate) reply_channel: ReplyChannel<StatusWatcher>,
 }
 
 /// Command for managing [`ServiceCore`](crate::services::ServiceCore) lifecycle
@@ -54,6 +62,7 @@ pub struct SettingsCommand(pub(crate) AnySettings);
 #[derive(Debug)]
 pub enum OverwatchCommand {
     Relay(RelayCommand),
+    Status(StatusCommand),
     ServiceLifeCycle(ServiceLifeCycleCommand),
     OverwatchLifeCycle(OverwatchLifeCycleCommand),
     Settings(SettingsCommand),

--- a/overwatch-rs/src/overwatch/handle.rs
+++ b/overwatch-rs/src/overwatch/handle.rs
@@ -1,7 +1,9 @@
 // std
 
 // crates
-use crate::overwatch::commands::{OverwatchCommand, OverwatchLifeCycleCommand, SettingsCommand};
+use crate::overwatch::commands::{
+    OverwatchCommand, OverwatchLifeCycleCommand, ReplyChannel, SettingsCommand, StatusCommand,
+};
 use crate::overwatch::Services;
 use crate::services::ServiceData;
 use tokio::runtime::Handle;
@@ -12,6 +14,7 @@ use tracing::{error, info};
 
 // internal
 use crate::services::relay::Relay;
+use crate::services::status::StatusWatcher;
 
 /// Handler object over the main Overwatch runner
 /// It handles communications to the main Overwatch runner.
@@ -33,6 +36,30 @@ impl OverwatchHandle {
     /// Request for a relay
     pub fn relay<S: ServiceData>(&self) -> Relay<S> {
         Relay::new(self.clone())
+    }
+
+    // Request a status watcher for a service
+    pub async fn status_watcher<S: ServiceData>(&self) -> StatusWatcher {
+        info!("Requesting status watcher for {}", S::SERVICE_ID);
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let watcher_request = self
+            .sender
+            .send(OverwatchCommand::Status(StatusCommand {
+                service_id: S::SERVICE_ID,
+                reply_channel: ReplyChannel::from(sender),
+            }))
+            .await;
+        match watcher_request {
+            Ok(_) => receiver.await.unwrap_or_else(|_| {
+                panic!(
+                    "Service {} watcher should always be available",
+                    S::SERVICE_ID
+                )
+            }),
+            Err(_) => {
+                unreachable!("Service watcher should always be available");
+            }
+        }
     }
 
     /// Send a shutdown signal to the overwatch runner

--- a/overwatch-rs/src/services/mod.rs
+++ b/overwatch-rs/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod life_cycle;
 pub mod relay;
 pub mod settings;
 pub mod state;
+pub mod status;
 
 // std
 use std::fmt::Debug;

--- a/overwatch-rs/src/services/status.rs
+++ b/overwatch-rs/src/services/status.rs
@@ -4,11 +4,20 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 // crates
-use crate::services::ServiceData;
+use crate::services::{ServiceData, ServiceId};
+use thiserror::Error;
 use tokio::sync::watch;
 // internal
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Error, Debug)]
+pub enum ServiceStatusError {
+    #[error("service {service_id} is not available")]
+    Unavailable { service_id: ServiceId },
+}
+
+pub type ServiceStatusResult = Result<StatusWatcher, ServiceStatusError>;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ServiceStatus {
     Uninitialized,
     Running,
@@ -25,7 +34,7 @@ impl StatusUpdater {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct StatusWatcher(watch::Receiver<ServiceStatus>);
 
 impl StatusWatcher {

--- a/overwatch-rs/src/services/status.rs
+++ b/overwatch-rs/src/services/status.rs
@@ -1,0 +1,77 @@
+// std
+use std::marker::PhantomData;
+use std::time::Duration;
+// crates
+use crate::services::ServiceData;
+use tokio::sync::watch;
+// internal
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum ServiceStatus {
+    Uninitialized,
+    Running,
+    Stopped,
+}
+
+pub struct StatusUpdater(watch::Sender<ServiceStatus>);
+
+impl StatusUpdater {
+    pub fn update(&self, status: ServiceStatus) {
+        self.0
+            .send(status)
+            .expect("Overwatch always maintain an open watcher, send should always succeed")
+    }
+}
+
+#[derive(Clone)]
+pub struct StatusWatcher(watch::Receiver<ServiceStatus>);
+
+impl StatusWatcher {
+    pub async fn wait_for(
+        &mut self,
+        status: ServiceStatus,
+        timeout_duration: Option<Duration>,
+    ) -> Result<ServiceStatus, ServiceStatus> {
+        let current = *self.0.borrow();
+        if status == current {
+            return Ok(current);
+        }
+        let timeout_duration = timeout_duration.unwrap_or_else(|| Duration::from_secs(u64::MAX));
+        tokio::time::timeout(timeout_duration, self.0.wait_for(|s| s == &status))
+            .await
+            .map(|r| r.map(|s| *s).map_err(|_| current))
+            .unwrap_or(Err(current))
+    }
+}
+
+pub struct StatusHandle<S: ServiceData> {
+    updater: StatusUpdater,
+    watcher: StatusWatcher,
+    _phantom: PhantomData<S>,
+}
+
+impl<S: ServiceData> StatusHandle<S> {
+    pub fn new() -> Self {
+        let (updater, watcher) = watch::channel(ServiceStatus::Uninitialized);
+        let updater = StatusUpdater(updater);
+        let watcher = StatusWatcher(watcher);
+        Self {
+            updater,
+            watcher,
+            _phantom: Default::default(),
+        }
+    }
+    pub fn updater(&self) -> &StatusUpdater {
+        &self.updater
+    }
+
+    pub fn watcher(&self) -> StatusWatcher {
+        self.watcher.clone()
+    }
+}
+
+impl<S: ServiceData> Default for StatusHandle<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/overwatch-rs/tests/sequence.rs
+++ b/overwatch-rs/tests/sequence.rs
@@ -1,0 +1,164 @@
+use overwatch_derive::Services;
+use overwatch_rs::overwatch::OverwatchRunner;
+use overwatch_rs::services::handle::{ServiceHandle, ServiceStateHandle};
+use overwatch_rs::services::relay::NoMessage;
+use overwatch_rs::services::state::{NoOperator, NoState};
+use overwatch_rs::services::status::{ServiceStatus, StatusWatcher};
+use overwatch_rs::services::{ServiceCore, ServiceData, ServiceId};
+use overwatch_rs::DynError;
+use std::time::Duration;
+
+pub struct AwaitService1 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService2 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+pub struct AwaitService3 {
+    service_state: ServiceStateHandle<Self>,
+}
+
+impl ServiceData for AwaitService1 {
+    const SERVICE_ID: ServiceId = "S1";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService2 {
+    const SERVICE_ID: ServiceId = "S2";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+impl ServiceData for AwaitService3 {
+    const SERVICE_ID: ServiceId = "S3";
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = NoMessage;
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService1 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        println!("Initialized 1");
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService2 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+
+        let mut watcher: StatusWatcher = self
+            .service_state
+            .overwatch_handle
+            .status_watcher::<AwaitService1>()
+            .await;
+
+        watcher
+            .wait_for(ServiceStatus::Running, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+
+        println!("Initialized 2");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        watcher
+            .wait_for(ServiceStatus::Stopped, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ServiceCore for AwaitService3 {
+    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+        Ok(Self { service_state })
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Running);
+
+        let mut watcher: StatusWatcher = self
+            .service_state
+            .overwatch_handle
+            .status_watcher::<AwaitService2>()
+            .await;
+
+        watcher
+            .wait_for(ServiceStatus::Running, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+
+        println!("Initialized 3");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        watcher
+            .wait_for(ServiceStatus::Stopped, Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        self.service_state
+            .status_handle
+            .updater()
+            .update(ServiceStatus::Stopped);
+        Ok(())
+    }
+}
+
+#[derive(Services)]
+struct SequenceServices {
+    c: ServiceHandle<AwaitService3>,
+    b: ServiceHandle<AwaitService2>,
+    a: ServiceHandle<AwaitService1>,
+}
+
+#[test]
+fn sequenced_services_startup() {
+    let settings = SequenceServicesServiceSettings {
+        a: (),
+        b: (),
+        c: (),
+    };
+    let overwatch = OverwatchRunner::<SequenceServices>::run(settings, None).unwrap();
+    let handle = overwatch.handle().clone();
+
+    overwatch.spawn(async move {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        handle.shutdown().await;
+    });
+    overwatch.wait_finished();
+}

--- a/overwatch-rs/tests/sequence.rs
+++ b/overwatch-rs/tests/sequence.rs
@@ -46,7 +46,10 @@ impl ServiceData for AwaitService3 {
 
 #[async_trait::async_trait]
 impl ServiceCore for AwaitService1 {
-    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+    fn init(
+        service_state: ServiceStateHandle<Self>,
+        _initial_state: Self::State,
+    ) -> Result<Self, DynError> {
         Ok(Self { service_state })
     }
 
@@ -67,7 +70,10 @@ impl ServiceCore for AwaitService1 {
 
 #[async_trait::async_trait]
 impl ServiceCore for AwaitService2 {
-    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+    fn init(
+        service_state: ServiceStateHandle<Self>,
+        _initial_state: Self::State,
+    ) -> Result<Self, DynError> {
         Ok(Self { service_state })
     }
 
@@ -104,7 +110,10 @@ impl ServiceCore for AwaitService2 {
 
 #[async_trait::async_trait]
 impl ServiceCore for AwaitService3 {
-    fn init(service_state: ServiceStateHandle<Self>) -> Result<Self, DynError> {
+    fn init(
+        service_state: ServiceStateHandle<Self>,
+        _initial_state: Self::State,
+    ) -> Result<Self, DynError> {
         Ok(Self { service_state })
     }
 


### PR DESCRIPTION
#### Sourced from: https://github.com/logos-co/Overwatch/pull/30
This PR includes the changes in https://github.com/logos-co/Overwatch/pull/30, and simply resolves the conflicts.

## Description

This is a better and simpler approach than #29 . Responsibility is of the services implementations (**With great power comes great responsibility**) to understand the complexities of their services relationships.

## How this works?

There is `tokio::sync::watch` channel handled by the service. Other services can subscribe and get updated requesting a watcher (watch::Receiver) from the calls in the overwatch_handle within services themselves. 
**Service status do not update automatically**, I think is more flexible as service may chose to mark when they are ready to work. Also when they have finished its exection.

`StatusHandle` holds both parts of the sender/receiver parts of the watch channel and its clonable. That way the service can spawn tasks freely and send the handle to handle internal status as well.