### PR TITLE
chore: improve trait bounds

### DIFF
--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -177,8 +177,8 @@ fn generate_new_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStr
         quote! {
             #field_identifier: {
                 let manager =
-                    ::overwatch_rs::OpaqueServiceHandle::<#service_type>::new(
-                        #settings_field_identifier, overwatch_handle.clone(),
+                    ::overwatch_rs::OpaqueServiceHandle::<#service_type>::new::<<#service_type as ::overwatch_rs::services::ServiceData>::StateOperator>(
+                        #settings_field_identifier, overwatch_handle.clone(), <#service_type as ::overwatch_rs::services::ServiceData>::SERVICE_RELAY_BUFFER_SIZE
                 )?;
                 manager
             }
@@ -203,8 +203,9 @@ fn generate_new_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStr
 fn generate_start_all_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStream {
     let call_start = fields.iter().map(|field| {
         let field_identifier = field.ident.as_ref().expect("A struct attribute identifier");
+        let type_id = utils::extract_type_from(&field.ty);
         quote! {
-            self.#field_identifier.service_runner().run()?
+            self.#field_identifier.service_runner::<<#type_id as ::overwatch_rs::services::ServiceData>::StateOperator>().run::<#type_id>()?
         }
     });
 
@@ -223,7 +224,7 @@ fn generate_start_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenS
         let type_id = utils::extract_type_from(&field.ty);
         quote! {
             <#type_id as ::overwatch_rs::services::ServiceData>::SERVICE_ID => {
-                self.#field_identifier.service_runner().run()?;
+                self.#field_identifier.service_runner::<<#type_id as ::overwatch_rs::services::ServiceData>::StateOperator>().run::<#type_id>()?;
                 ::std::result::Result::Ok(())
             }
         }

--- a/overwatch-rs/src/lib.rs
+++ b/overwatch-rs/src/lib.rs
@@ -34,13 +34,11 @@ pub type DynError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type OpaqueServiceHandle<S> = crate::services::handle::ServiceHandle<
     <S as ServiceData>::Message,
     <S as ServiceData>::Settings,
-    S,
     <S as ServiceData>::State,
 >;
 pub type OpaqueServiceStateHandle<S> = crate::services::handle::ServiceStateHandle<
     <S as ServiceData>::Message,
     <S as ServiceData>::Settings,
-    S,
     <S as ServiceData>::State,
 >;
 

--- a/overwatch-rs/src/services/handle.rs
+++ b/overwatch-rs/src/services/handle.rs
@@ -28,6 +28,28 @@ pub struct ServiceHandle<Message, Settings, State> {
     relay_buffer_size: usize,
 }
 
+/// Service core resources
+/// It contains whatever is necessary to start a new service runner
+pub struct ServiceStateHandle<Message, Settings, State> {
+    /// Relay channel to communicate with the service runner
+    pub inbound_relay: InboundRelay<Message>,
+    pub status_handle: StatusHandle,
+    /// Overwatch handle
+    pub overwatch_handle: OverwatchHandle,
+    pub settings_reader: SettingsNotifier<Settings>,
+    pub state_updater: StateUpdater<State>,
+    pub lifecycle_handle: LifecycleHandle,
+}
+
+/// Main service executor
+/// It is the object that hold the necessary information for the service to run
+pub struct ServiceRunner<Message, Settings, State, StateOperator> {
+    service_state: ServiceStateHandle<Message, Settings, State>,
+    state_handle: StateHandle<State, StateOperator>,
+    lifecycle_handle: LifecycleHandle,
+    initial_state: State,
+}
+
 impl<Message, Settings, State> ServiceHandle<Message, Settings, State>
 where
     Settings: Clone,
@@ -118,28 +140,6 @@ where
             initial_state: self.initial_state.clone(),
         }
     }
-}
-
-/// Service core resources
-/// It contains whatever is necessary to start a new service runner
-pub struct ServiceStateHandle<Message, Settings, State> {
-    /// Relay channel to communicate with the service runner
-    pub inbound_relay: InboundRelay<Message>,
-    pub status_handle: StatusHandle,
-    /// Overwatch handle
-    pub overwatch_handle: OverwatchHandle,
-    pub settings_reader: SettingsNotifier<Settings>,
-    pub state_updater: StateUpdater<State>,
-    pub lifecycle_handle: LifecycleHandle,
-}
-
-/// Main service executor
-/// It is the object that hold the necessary information for the service to run
-pub struct ServiceRunner<Message, Settings, State, StateOperator> {
-    service_state: ServiceStateHandle<Message, Settings, State>,
-    state_handle: StateHandle<State, StateOperator>,
-    lifecycle_handle: LifecycleHandle,
-    initial_state: State,
 }
 
 impl<Message, Settings, State, StateOp> ServiceRunner<Message, Settings, State, StateOp>

--- a/overwatch-rs/src/services/handle.rs
+++ b/overwatch-rs/src/services/handle.rs
@@ -8,14 +8,14 @@ use crate::services::relay::{relay, InboundRelay, OutboundRelay};
 use crate::services::settings::{SettingsNotifier, SettingsUpdater};
 use crate::services::state::{StateHandle, StateOperator, StateUpdater};
 use crate::services::status::{StatusHandle, StatusWatcher};
-use crate::services::{ServiceCore, ServiceData, ServiceId, ServiceState};
+use crate::services::{ServiceCore, ServiceId, ServiceState};
 
 // TODO: Abstract handle over state, to differentiate when the service is running and when it is not
 // that way we can expose a better API depending on what is happenning. Would get rid of the probably
 // unnecessary Option and cloning.
 /// Service handle
 /// This is used to access different parts of the service
-pub struct ServiceHandle<Message, Settings, Data, State> {
+pub struct ServiceHandle<Message, Settings, State> {
     /// Message channel relay
     /// Would be None if service is not running
     /// Will contain the channel if service is running
@@ -23,52 +23,31 @@ pub struct ServiceHandle<Message, Settings, Data, State> {
     /// Handle to overwatch
     overwatch_handle: OverwatchHandle,
     settings: SettingsUpdater<Settings>,
-    status: StatusHandle<Data>,
+    status: StatusHandle,
     initial_state: State,
+    relay_buffer_size: usize,
 }
 
-/// Service core resources
-/// It contains whatever is necessary to start a new service runner
-pub struct ServiceStateHandle<Message, Settings, Data, State> {
-    /// Relay channel to communicate with the service runner
-    pub inbound_relay: InboundRelay<Message>,
-    pub status_handle: StatusHandle<Data>,
-    /// Overwatch handle
-    pub overwatch_handle: OverwatchHandle,
-    pub settings_reader: SettingsNotifier<Settings>,
-    pub state_updater: StateUpdater<State>,
-    pub lifecycle_handle: LifecycleHandle,
-}
-
-/// Main service executor
-/// It is the object that hold the necessary information for the service to run
-pub struct ServiceRunner<Message, Settings, Data, State, StateOperator> {
-    service_state: ServiceStateHandle<Message, Settings, Data, State>,
-    state_handle: StateHandle<State, StateOperator>,
-    lifecycle_handle: LifecycleHandle,
-    initial_state: State,
-}
-
-impl<Service> ServiceHandle<Service::Message, Service::Settings, Service, Service::State>
+impl<Message, Settings, State> ServiceHandle<Message, Settings, State>
 where
-    Service: ServiceData,
-    Service::State: ServiceState<Settings = Service::Settings> + Clone,
-    Service::Settings: Clone,
-    Service::StateOperator:
-        StateOperator<Settings = Service::Settings, StateInput = Service::State>,
+    Settings: Clone,
+    State: ServiceState<Settings = Settings> + Clone,
 {
-    pub fn new(
-        settings: Service::Settings,
+    pub fn new<StateOp>(
+        settings: Settings,
         overwatch_handle: OverwatchHandle,
-    ) -> Result<Self, <Service::State as ServiceState>::Error> {
-        let initial_state =
-            if let Ok(Some(loaded_state)) = Service::StateOperator::try_load(&settings) {
-                info!("Loaded state from Operator");
-                loaded_state
-            } else {
-                info!("Couldn't load state from Operator. Creating from settings.");
-                Service::State::from_settings(&settings)?
-            };
+        relay_buffer_size: usize,
+    ) -> Result<Self, State::Error>
+    where
+        StateOp: StateOperator<Settings = Settings, StateInput = State>,
+    {
+        let initial_state = if let Ok(Some(loaded_state)) = StateOp::try_load(&settings) {
+            info!("Loaded state from Operator");
+            loaded_state
+        } else {
+            info!("Couldn't load state from Operator. Creating from settings.");
+            State::from_settings(&settings)?
+        };
 
         Ok(Self {
             outbound_relay: None,
@@ -76,11 +55,8 @@ where
             settings: SettingsUpdater::new(settings),
             status: StatusHandle::new(),
             initial_state,
+            relay_buffer_size,
         })
-    }
-
-    pub fn id(&self) -> ServiceId {
-        Service::SERVICE_ID
     }
 
     /// Service runtime getter
@@ -96,7 +72,7 @@ where
     }
 
     /// Request a relay with this service
-    pub fn relay_with(&self) -> Option<OutboundRelay<Service::Message>> {
+    pub fn relay_with(&self) -> Option<OutboundRelay<Message>> {
         self.outbound_relay.clone()
     }
 
@@ -105,33 +81,24 @@ where
     }
 
     /// Update settings
-    pub fn update_settings(&self, settings: Service::Settings) {
+    pub fn update_settings(&self, settings: Settings) {
         self.settings.update(settings);
     }
 
     /// Build a runner for this service
-    pub fn service_runner(
-        &mut self,
-    ) -> ServiceRunner<
-        Service::Message,
-        Service::Settings,
-        Service,
-        Service::State,
-        Service::StateOperator,
-    > {
+    pub fn service_runner<StateOp>(&mut self) -> ServiceRunner<Message, Settings, State, StateOp>
+    where
+        StateOp: StateOperator<Settings = Settings>,
+    {
         // TODO: add proper status handling here, a service should be able to produce a runner if it is already running.
-        let (inbound_relay, outbound_relay) =
-            relay::<Service::Message>(Service::SERVICE_RELAY_BUFFER_SIZE);
+        let (inbound_relay, outbound_relay) = relay::<Message>(self.relay_buffer_size);
         let settings_reader = self.settings.notifier();
         // add relay channel to handle
         self.outbound_relay = Some(outbound_relay);
         let settings = self.settings.notifier().get_updated_settings();
-        let operator = Service::StateOperator::from_settings(settings);
+        let operator = StateOp::from_settings(settings);
         let (state_handle, state_updater) =
-            StateHandle::<Service::State, Service::StateOperator>::new(
-                self.initial_state.clone(),
-                operator,
-            );
+            StateHandle::<State, StateOp>::new(self.initial_state.clone(), operator);
 
         let lifecycle_handle = LifecycleHandle::new();
 
@@ -153,37 +120,45 @@ where
     }
 }
 
-impl<Service> ServiceStateHandle<Service::Message, Service::Settings, Service, Service::State>
-where
-    Service: ServiceData,
-{
-    #[must_use]
-    pub fn id(&self) -> ServiceId {
-        Service::SERVICE_ID
-    }
+/// Service core resources
+/// It contains whatever is necessary to start a new service runner
+pub struct ServiceStateHandle<Message, Settings, State> {
+    /// Relay channel to communicate with the service runner
+    pub inbound_relay: InboundRelay<Message>,
+    pub status_handle: StatusHandle,
+    /// Overwatch handle
+    pub overwatch_handle: OverwatchHandle,
+    pub settings_reader: SettingsNotifier<Settings>,
+    pub state_updater: StateUpdater<State>,
+    pub lifecycle_handle: LifecycleHandle,
 }
 
-impl<Service>
-    ServiceRunner<
-        Service::Message,
-        Service::Settings,
-        Service,
-        Service::State,
-        Service::StateOperator,
-    >
+/// Main service executor
+/// It is the object that hold the necessary information for the service to run
+pub struct ServiceRunner<Message, Settings, State, StateOperator> {
+    service_state: ServiceStateHandle<Message, Settings, State>,
+    state_handle: StateHandle<State, StateOperator>,
+    lifecycle_handle: LifecycleHandle,
+    initial_state: State,
+}
+
+impl<Message, Settings, State, StateOp> ServiceRunner<Message, Settings, State, StateOp>
 where
-    Service: ServiceCore + 'static,
-    Service::State: Clone + Send + Sync + 'static,
-    Service::StateOperator: StateOperator<StateInput = Service::State> + Send,
+    State: Clone + Send + Sync + 'static,
+    StateOp: StateOperator<StateInput = State> + Send + 'static,
 {
     /// Spawn the service main loop and handle it lifecycle
     /// Return a handle to abort execution manually
-    pub fn run(self) -> Result<(ServiceId, LifecycleHandle), crate::DynError> {
+    pub fn run<Service>(self) -> Result<(ServiceId, LifecycleHandle), crate::DynError>
+    where
+        Service: ServiceCore<Settings = Settings, State = State, Message = Message> + 'static,
+    {
         let ServiceRunner {
             service_state,
             state_handle,
             lifecycle_handle,
             initial_state,
+            ..
         } = self;
 
         let runtime = service_state.overwatch_handle.runtime().clone();

--- a/overwatch-rs/src/services/mod.rs
+++ b/overwatch-rs/src/services/mod.rs
@@ -43,7 +43,7 @@ pub trait ServiceData {
 pub trait ServiceCore: Sized + ServiceData {
     /// Initialize the service with the given state
     fn init(
-        service_state: ServiceStateHandle<Self::Message, Self::Settings, Self, Self::State>,
+        service_state: ServiceStateHandle<Self::Message, Self::Settings, Self::State>,
         initial_state: Self::State,
     ) -> Result<Self, super::DynError>;
 

--- a/overwatch-rs/src/services/status.rs
+++ b/overwatch-rs/src/services/status.rs
@@ -1,10 +1,9 @@
 // std
 use std::default::Default;
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 // crates
-use crate::services::{ServiceData, ServiceId};
+use crate::services::ServiceId;
 use thiserror::Error;
 use tokio::sync::watch;
 // internal
@@ -55,36 +54,27 @@ impl StatusWatcher {
     }
 }
 
-pub struct StatusHandle<Status> {
+pub struct StatusHandle {
     updater: Arc<StatusUpdater>,
     watcher: StatusWatcher,
-    _phantom: PhantomData<Status>,
 }
 
-impl<Status> Clone for StatusHandle<Status>
-where
-    Status: ServiceData,
-{
+impl Clone for StatusHandle {
     fn clone(&self) -> Self {
         Self {
             updater: Arc::clone(&self.updater),
             watcher: self.watcher.clone(),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<Status> StatusHandle<Status> {
+impl StatusHandle {
     #[must_use]
     pub fn new() -> Self {
         let (updater, watcher) = watch::channel(ServiceStatus::Uninitialized);
         let updater = Arc::new(StatusUpdater(updater));
         let watcher = StatusWatcher(watcher);
-        Self {
-            updater,
-            watcher,
-            _phantom: PhantomData,
-        }
+        Self { updater, watcher }
     }
     #[must_use]
     pub fn updater(&self) -> &StatusUpdater {
@@ -96,7 +86,7 @@ impl<Status> StatusHandle<Status> {
     }
 }
 
-impl<Status> Default for StatusHandle<Status> {
+impl Default for StatusHandle {
     fn default() -> Self {
         Self::new()
     }

--- a/overwatch-rs/tests/generics.rs
+++ b/overwatch-rs/tests/generics.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 pub struct GenericService {
-    state: ServiceStateHandle<GenericServiceMessage, (), Self, NoState<()>>,
+    state: ServiceStateHandle<GenericServiceMessage, (), NoState<()>>,
 }
 
 #[derive(Clone, Debug)]
@@ -28,7 +28,7 @@ impl ServiceData for GenericService {
 #[async_trait]
 impl ServiceCore for GenericService {
     fn init(
-        state: ServiceStateHandle<Self::Message, Self::Settings, Self, Self::State>,
+        state: ServiceStateHandle<Self::Message, Self::Settings, Self::State>,
         _initial_state: Self::State,
     ) -> Result<Self, overwatch_rs::DynError> {
         Ok(Self { state })

--- a/overwatch-rs/tests/print_service.rs
+++ b/overwatch-rs/tests/print_service.rs
@@ -39,9 +39,10 @@ impl ServiceCore for PrintService {
         use tokio::io::{self, AsyncWriteExt};
 
         let Self {
-            state: OpaqueServiceStateHandle {
-                mut inbound_relay, ..
-            },
+            state:
+                OpaqueServiceStateHandle::<Self> {
+                    mut inbound_relay, ..
+                },
         } = self;
 
         let print = async move {

--- a/overwatch-rs/tests/settings_update.rs
+++ b/overwatch-rs/tests/settings_update.rs
@@ -38,9 +38,10 @@ impl ServiceCore for SettingsService {
 
     async fn run(mut self) -> Result<(), overwatch_rs::DynError> {
         let Self {
-            state: OpaqueServiceStateHandle {
-                settings_reader, ..
-            },
+            state:
+                OpaqueServiceStateHandle::<Self> {
+                    settings_reader, ..
+                },
         } = self;
 
         let print = async move {

--- a/overwatch-rs/tests/state_handling.rs
+++ b/overwatch-rs/tests/state_handling.rs
@@ -93,7 +93,7 @@ impl ServiceCore for UpdateStateService {
 
     async fn run(mut self) -> Result<(), overwatch_rs::DynError> {
         let Self {
-            state: OpaqueServiceStateHandle { state_updater, .. },
+            state: OpaqueServiceStateHandle::<Self> { state_updater, .. },
         } = self;
         for value in 0..10 {
             state_updater.update(CounterState { value });


### PR DESCRIPTION
PR built on top of the previous one (https://github.com/logos-co/Overwatch/pull/46), which improves the ergonomics. Some generics and their trait bounds were removed where not needed, and replaced by a couple of turbofish-syntax ones in the functions that required them.