### PR TITLE
chore: overwatch refactoring

### DIFF
--- a/examples/ping_pong/src/messages.rs
+++ b/examples/ping_pong/src/messages.rs
@@ -1,16 +1,9 @@
-// Crate
-use overwatch::services::relay::RelayMessage;
-
 #[derive(Debug)]
 pub enum PingMessage {
     Pong,
 }
 
-impl RelayMessage for PingMessage {}
-
 #[derive(Debug)]
 pub enum PongMessage {
     Ping,
 }
-
-impl RelayMessage for PongMessage {}

--- a/examples/ping_pong/src/service_ping.rs
+++ b/examples/ping_pong/src/service_ping.rs
@@ -49,7 +49,6 @@ impl ServiceCore for PingService {
         let pong_outbound_relay = service_state_handle
             .overwatch_handle
             .relay::<PongService>()
-            .connect()
             .await?;
 
         let Self::State { mut pong_count } = initial_state;

--- a/examples/ping_pong/src/service_pong.rs
+++ b/examples/ping_pong/src/service_pong.rs
@@ -43,7 +43,6 @@ impl ServiceCore for PongService {
         let ping_outbound_relay = service_state_handle
             .overwatch_handle
             .relay::<PingService>()
-            .connect()
             .await?;
 
         while let Some(message) = inbound_relay.recv().await {

--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -8,20 +8,19 @@ use tokio::{
 use tracing::instrument;
 use tracing::{error, info};
 
-// internal
-use crate::{
-    overwatch::commands::RelayCommand,
-    services::relay::{OutboundRelay, RelayError},
-};
 use crate::{
     overwatch::{
         commands::{
-            OverwatchCommand, OverwatchLifeCycleCommand, ReplyChannel, SettingsCommand,
-            StatusCommand,
+            OverwatchCommand, OverwatchLifeCycleCommand, RelayCommand, ReplyChannel,
+            SettingsCommand, StatusCommand,
         },
         Services,
     },
-    services::{status::StatusWatcher, ServiceData},
+    services::{
+        relay::{OutboundRelay, RelayError},
+        status::StatusWatcher,
+        ServiceData,
+    },
 };
 
 /// Handler object over the main [`crate::overwatch::Overwatch`] runner.

--- a/overwatch/src/overwatch/life_cycle.rs
+++ b/overwatch/src/overwatch/life_cycle.rs
@@ -87,8 +87,8 @@ impl ServicesLifeCycleHandle {
     }
 
     /// Get all [`ServiceId`]s registered in this handle
-    pub fn services_ids(&self) -> impl Iterator<Item = ServiceId> + '_ {
-        self.handlers.keys().copied()
+    pub fn services_ids(&self) -> impl Iterator<Item = &ServiceId> {
+        self.handlers.keys()
     }
 }
 

--- a/overwatch/src/overwatch/mod.rs
+++ b/overwatch/src/overwatch/mod.rs
@@ -142,8 +142,6 @@ pub trait Services: Sized {
 /// That is, it's responsible for [`Overwatch`]'s application lifecycle.
 pub struct OverwatchRunner<Services> {
     services: Services,
-    #[expect(unused)]
-    handle: OverwatchHandle,
     finish_signal_sender: oneshot::Sender<()>,
     commands_receiver: Receiver<OverwatchCommand>,
 }
@@ -179,7 +177,6 @@ where
         let services = ServicesImpl::new(settings, handle.clone())?;
         let runner = Self {
             services,
-            handle: handle.clone(),
             finish_signal_sender,
             commands_receiver,
         };

--- a/overwatch/src/overwatch/mod.rs
+++ b/overwatch/src/overwatch/mod.rs
@@ -24,8 +24,7 @@ use crate::{
         handle::OverwatchHandle,
     },
     services::{
-        life_cycle::LifecycleMessage, relay::RelayResult, status::ServiceStatusResult,
-        ServiceError, ServiceId,
+        life_cycle::LifecycleMessage, relay::RelayResult, status::ServiceStatusResult, ServiceId,
     },
     utils::runtime::default_multithread_runtime,
 };
@@ -33,9 +32,6 @@ use crate::{
 /// Overwatch base error type.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
-    Relay(#[from] ServiceError),
-
     #[error("Service {service_id} is unavailable")]
     Unavailable { service_id: ServiceId },
 
@@ -97,7 +93,7 @@ pub trait Services: Sized {
 
     // TODO: this probably will be removed once the services lifecycle is
     // implemented
-    /// Start all services attaches to the trait implementer.
+    /// Start all services attached to the trait implementer.
     ///
     /// # Errors
     ///

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -5,15 +5,9 @@ pub mod settings;
 pub mod state;
 pub mod status;
 
-use std::fmt::Debug;
-
 use async_trait::async_trait;
 use handle::ServiceStateHandle;
 use state::ServiceState;
-use thiserror::Error;
-use tokio::runtime;
-
-use crate::services::relay::RelayError;
 
 // TODO: Make this type unique for each service?
 /// Services identification type.
@@ -51,31 +45,4 @@ pub trait ServiceCore: Sized + ServiceData {
 
     /// Main loop
     async fn run(mut self) -> Result<(), super::DynError>;
-}
-
-#[derive(Error, Debug)]
-pub enum ServiceError {
-    #[error(transparent)]
-    RelayError(#[from] RelayError),
-}
-
-pub enum ServiceRuntime {
-    FromParent(runtime::Handle),
-    Custom(runtime::Runtime),
-}
-
-impl ServiceRuntime {
-    pub fn handle(&self) -> runtime::Handle {
-        match self {
-            Self::FromParent(handle) => handle.clone(),
-            Self::Custom(runtime) => runtime.handle().clone(),
-        }
-    }
-
-    pub fn runtime(self) -> Option<runtime::Runtime> {
-        match self {
-            Self::Custom(runtime) => Some(runtime),
-            Self::FromParent(_) => None,
-        }
-    }
 }

--- a/overwatch/src/services/relay.rs
+++ b/overwatch/src/services/relay.rs
@@ -22,8 +22,6 @@ pub enum RelayError {
     Send,
     #[error("relay is already connected")]
     AlreadyConnected,
-    #[error("service relay is disconnected")]
-    Disconnected,
     #[error("service {service_id} is not available")]
     Unavailable { service_id: ServiceId },
     #[error("invalid message with type id [{type_id}] for service {service_id}")]
@@ -59,28 +57,17 @@ pub struct OutboundRelay<Message> {
 
 pub struct Relay<Service> {
     overwatch_handle: OverwatchHandle,
-    _bound: PhantomBound<Service>,
+    _bound: PhantomData<Service>,
 }
 
 impl<Service> Clone for Relay<Service> {
     fn clone(&self) -> Self {
         Self {
             overwatch_handle: self.overwatch_handle.clone(),
-            _bound: PhantomBound {
-                _inner: PhantomData,
-            },
+            _bound: PhantomData,
         }
     }
 }
-
-// Like PhantomData<T> but without ownership of T
-#[derive(Debug)]
-struct PhantomBound<T> {
-    _inner: PhantomData<*const T>,
-}
-
-unsafe impl<T> Send for PhantomBound<T> {}
-unsafe impl<T> Sync for PhantomBound<T> {}
 
 impl<Message> Clone for OutboundRelay<Message> {
     fn clone(&self) -> Self {

--- a/overwatch/src/services/settings.rs
+++ b/overwatch/src/services/settings.rs
@@ -1,4 +1,3 @@
-// crates
 use tokio::sync::watch::{channel, Receiver, Sender};
 use tracing::error;
 #[cfg(feature = "instrumentation")]

--- a/overwatch/src/utils/const_checks.rs
+++ b/overwatch/src/utils/const_checks.rs
@@ -1,4 +1,3 @@
-// internal
 use crate::services::ServiceId;
 
 #[must_use]

--- a/overwatch/tests/cancelable_service.rs
+++ b/overwatch/tests/cancelable_service.rs
@@ -80,7 +80,7 @@ fn run_overwatch_then_shutdown_service_and_kill() {
     let (sender, mut receiver) = tokio::sync::broadcast::channel(1);
     overwatch.spawn(async move {
         sleep(Duration::from_millis(500)).await;
-        handle
+        let _ = handle
             .send(OverwatchCommand::ServiceLifeCycle(
                 ServiceLifeCycleCommand {
                     service_id: <CancellableService as ServiceData>::SERVICE_ID,

--- a/overwatch/tests/generics.rs
+++ b/overwatch/tests/generics.rs
@@ -97,11 +97,10 @@ fn derive_generic_service() {
     };
     let overwatch = OverwatchRunner::<TestApp>::run(settings, None).unwrap();
     let handle = overwatch.handle().clone();
-    let generic_service_relay = handle.relay::<GenericService>();
 
     overwatch.spawn(async move {
-        let generic_service_relay = generic_service_relay
-            .connect()
+        let generic_service_relay = handle
+            .relay::<GenericService>()
             .await
             .expect("A connection to the generic service is established");
 
@@ -118,6 +117,7 @@ fn derive_generic_service() {
             .expect("stop message to be sent");
     });
 
+    let handle = overwatch.handle().clone();
     overwatch.spawn(async move {
         sleep(Duration::from_secs(1)).await;
         handle.shutdown().await;

--- a/overwatch/tests/print_service.rs
+++ b/overwatch/tests/print_service.rs
@@ -5,7 +5,6 @@ use futures::future::select;
 use overwatch::{
     overwatch::OverwatchRunner,
     services::{
-        relay::RelayMessage,
         state::{NoOperator, NoState},
         ServiceCore, ServiceData, ServiceId,
     },
@@ -20,8 +19,6 @@ pub struct PrintService {
 
 #[derive(Clone, Debug)]
 pub struct PrintServiceMessage(String);
-
-impl RelayMessage for PrintServiceMessage {}
 
 impl ServiceData for PrintService {
     const SERVICE_ID: ServiceId = "FooService";
@@ -97,11 +94,10 @@ fn derive_print_service() {
     let settings: TestAppServiceSettings = TestAppServiceSettings { print_service: () };
     let overwatch = OverwatchRunner::<TestApp>::run(settings, None).unwrap();
     let handle = overwatch.handle().clone();
-    let print_service_relay = handle.relay::<PrintService>();
 
     overwatch.spawn(async move {
-        let print_service_relay = print_service_relay
-            .connect()
+        let print_service_relay = handle
+            .relay::<PrintService>()
             .await
             .expect("A connection to the print service is established");
 
@@ -118,6 +114,7 @@ fn derive_print_service() {
             .expect("stop message to be sent");
     });
 
+    let handle = overwatch.handle().clone();
     overwatch.spawn(async move {
         sleep(Duration::from_secs(1)).await;
         handle.shutdown().await;

--- a/overwatch/tests/settings_update.rs
+++ b/overwatch/tests/settings_update.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use overwatch::{
     overwatch::OverwatchRunner,
     services::{
-        relay::RelayMessage,
         state::{NoOperator, NoState},
         ServiceCore, ServiceData, ServiceId,
     },
@@ -21,8 +20,6 @@ type SettingsServiceSettings = String;
 
 #[derive(Clone, Debug)]
 pub struct SettingsMsg;
-
-impl RelayMessage for SettingsMsg {}
 
 impl ServiceData for SettingsService {
     const SERVICE_ID: ServiceId = "FooService";

--- a/overwatch/tests/state_handling.rs
+++ b/overwatch/tests/state_handling.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use overwatch::{
     overwatch::OverwatchRunner,
     services::{
-        relay::RelayMessage,
         state::{ServiceState, StateOperator},
         ServiceCore, ServiceData, ServiceId,
     },
@@ -22,8 +21,6 @@ pub struct UpdateStateService {
 
 #[derive(Clone, Debug)]
 pub struct UpdateStateServiceMessage;
-
-impl RelayMessage for UpdateStateServiceMessage {}
 
 #[derive(Debug)]
 pub struct UnitError;

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -1,6 +1,5 @@
 use std::{thread, time::Duration};
 
-// Crates
 use async_trait::async_trait;
 use overwatch::{
     overwatch::OverwatchRunner,


### PR DESCRIPTION
This is a small refactoring of the overwatch framework based on findings while working on the [compile-time checks](https://github.com/logos-co/Overwatch/pull/58).

This PR introduces the following:

* Removal of the `RelayMessage` trait, which is not needed anymore after all trait bounds where removed from traits
* The `OverwatchHandle::relay` method has been updated to match the behaviour of the other methods within the same type. Namely, the function is now `async`, and it returns a fully-created `OutboundRelay` which is the result of trying to create a channel with a given service, and parsing the response message
* The other functions within the `OverwatchHandle` type have also been updated to use the `send` function of the same type, which has been updated to return whatever error is thrown during the send process, instead of the old behaviour of logging it and ignoring it
* Removal of unused enum error variants and properties

I tried to maintain the same behaviour wherever possible, especially regarding how errors are captured and logged, including panics.