### PR TITLE
feat: compile-time lifecycle handlers

### DIFF
--- a/examples/ping_pong/src/main.rs
+++ b/examples/ping_pong/src/main.rs
@@ -11,8 +11,8 @@ mod states;
 
 #[derive_services]
 struct PingPong {
-    ping_service: PingService,
-    pong_service: PongService,
+    ping: PingService,
+    pong: PongService,
 }
 
 const PING_STATE_SAVE_PATH: &str = const_format::formatcp!(
@@ -25,8 +25,8 @@ fn main() {
         state_save_path: String::from(PING_STATE_SAVE_PATH),
     };
     let ping_pong_settings = PingPongServiceSettings {
-        ping_service: ping_settings,
-        pong_service: (),
+        ping: ping_settings,
+        pong: (),
     };
     let ping_pong =
         OverwatchRunner::<PingPong>::run(ping_pong_settings, None).expect("OverwatchRunner failed");

--- a/examples/ping_pong/src/main.rs
+++ b/examples/ping_pong/src/main.rs
@@ -11,8 +11,8 @@ mod states;
 
 #[derive_services]
 struct PingPong {
-    ping: PingService,
-    pong: PongService,
+    ping_service: PingService,
+    pong_service: PongService,
 }
 
 const PING_STATE_SAVE_PATH: &str = const_format::formatcp!(
@@ -25,8 +25,8 @@ fn main() {
         state_save_path: String::from(PING_STATE_SAVE_PATH),
     };
     let ping_pong_settings = PingPongServiceSettings {
-        ping: ping_settings,
-        pong: (),
+        ping_service: ping_settings,
+        pong_service: (),
     };
     let ping_pong =
         OverwatchRunner::<PingPong>::run(ping_pong_settings, None).expect("OverwatchRunner failed");

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -254,8 +254,8 @@ fn generate_start_all_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::To
     let instrumentation = get_default_instrumentation_for_result();
     quote! {
         #instrumentation
-        fn start_all(&mut self) -> ::core::result::Result<Self::RuntimeLifeCycleHandlers, ::overwatch::overwatch::Error> {
-            ::core::result::Result::Ok(Self::RuntimeLifeCycleHandlers {
+        fn start_all(&mut self) -> ::core::result::Result<Self::ServicesLifeCycleHandle, ::overwatch::overwatch::Error> {
+            ::core::result::Result::Ok(Self::ServicesLifeCycleHandle {
                 #( #call_start ),*
             })
         }

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -162,6 +162,11 @@ fn get_runtime_service_id_type_name() -> Type {
     parse_str(RUNTIME_SERVICE_ID_TYPE_NAME)
         .expect("Runtime service ID type is a valid type token stream.")
 }
+const RUNTIME_LIFECYCLE_HANDLERS_TYPE_NAME: &str = "RuntimeLifeCycleHandlers";
+fn get_runtime_lifecycle_handlers_type_name() -> Type {
+    parse_str(RUNTIME_LIFECYCLE_HANDLERS_TYPE_NAME)
+        .expect("Runtime lifecycle handlers type is a valid type token stream.")
+}
 
 fn generate_services_impl(
     services_identifier: &proc_macro2::Ident,
@@ -180,11 +185,12 @@ fn generate_services_impl(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let runtime_service_id_type_name = get_runtime_service_id_type_name();
+    let runtime_lifecycle_handlers_type_name = get_runtime_lifecycle_handlers_type_name();
     quote! {
         impl #impl_generics ::overwatch::overwatch::Services for #services_identifier #ty_generics #where_clause {
             type Settings = #services_settings_identifier #ty_generics;
             type RuntimeServiceId = #runtime_service_id_type_name;
-            type ServicesLifeCycleHandle = RuntimeLifeCycleHandlers;
+            type ServicesLifeCycleHandle = #runtime_lifecycle_handlers_type_name;
 
             #impl_new
 
@@ -549,12 +555,13 @@ pub fn generate_lifecyle_handlers(input: TokenStream) -> TokenStream {
     });
 
     let runtime_service_id_type_name = get_runtime_service_id_type_name();
+    let runtime_lifecycle_handlers_type_name = get_runtime_lifecycle_handlers_type_name();
     let expanded = quote! {
-        pub struct RuntimeLifeCycleHandlers {
+        pub struct #runtime_lifecycle_handlers_type_name {
             #(#struct_fields,)*
         }
 
-        impl ::overwatch::overwatch::life_cycle::ServicesLifeCycleHandle<#runtime_service_id_type_name> for RuntimeLifeCycleHandlers {
+        impl ::overwatch::overwatch::life_cycle::ServicesLifeCycleHandle<#runtime_service_id_type_name> for #runtime_lifecycle_handlers_type_name {
             type Error = ::overwatch::DynError;
 
             /// Send a `Shutdown` message to the specified service.

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -427,7 +427,7 @@ fn generate_runtime_service_id(fields: &Punctuated<Field, Comma>) -> proc_macro2
     });
     let runtime_service_id_type_name = get_runtime_service_id_type_name();
     let expanded = quote! {
-        #[derive(::core::fmt::Debug, ::core::clone::Clone, ::core::marker::Copy, ::core::cmp::PartialEq, ::core::cmp::Eq, ::core::hash::Hash, ::overwatch::LifecycleHandlers)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone, ::core::marker::Copy, ::core::cmp::PartialEq, ::core::cmp::Eq, ::overwatch::LifecycleHandlers)]
         pub enum #runtime_service_id_type_name {
             #(#enum_variants),*
         }
@@ -524,12 +524,13 @@ fn generate_service_id_impls(fields: &Punctuated<Field, Comma>) -> proc_macro2::
 #[proc_macro_derive(LifecycleHandlers)]
 pub fn generate_lifecyle_handlers(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+
     let enum_name = input.ident;
+    assert!(enum_name == RUNTIME_SERVICE_ID_TYPE_NAME, "LifecycleHandlers` can only be implemented on the runtime service ID type generated within this macro.");
 
     let Data::Enum(data_enum) = input.data else {
         panic!("`LifecycleHandlers` can only be used on enums.");
     };
-    assert!(enum_name == RUNTIME_SERVICE_ID_TYPE_NAME, "LifecycleHandlers` can only be implemented on the runtime service ID type generated within this macro.");
 
     let variants_names = data_enum.variants.iter().map(|variant| &variant.ident);
     let variants_as_field_names = variants_names.clone().map(|variant_name| {

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -526,22 +526,25 @@ pub fn generate_lifecyle_handlers(input: TokenStream) -> TokenStream {
 
     let fields: Vec<Ident> = data_enum.variants.iter().map(|v| v.ident.clone()).collect();
     let struct_fields = fields.iter().map(|name| {
-        let field_name = Ident::new(&name.to_string().to_lowercase(), name.span());
+        let field_name = Ident::new(
+            &utils::enum_variant_name_to_field_name(&name.to_string()),
+            name.span(),
+        );
         quote! { #field_name: ::overwatch::services::life_cycle::LifecycleHandle }
     });
 
     let match_arms_shutdown = fields.iter().map(|name| {
-        let field_name = Ident::new(&name.to_string().to_lowercase(), name.span());
+        let field_name = Ident::new(&utils::enum_variant_name_to_field_name(&name.to_string()), name.span());
         quote! { &#enum_name::#name => self.#field_name.send(::overwatch::services::life_cycle::LifecycleMessage::Shutdown(sender)) }
     });
 
     let match_arms_kill = fields.iter().map(|name| {
-        let field_name = Ident::new(&name.to_string().to_lowercase(), name.span());
+        let field_name = Ident::new(&utils::enum_variant_name_to_field_name(&name.to_string()), name.span());
         quote! { &#enum_name::#name => self.#field_name.send(::overwatch::services::life_cycle::LifecycleMessage::Kill) }
     });
 
     let kill_all_body = fields.iter().map(|name| {
-        let field_name = Ident::new(&name.to_string().to_lowercase(), name.span());
+        let field_name = Ident::new(&utils::enum_variant_name_to_field_name(&name.to_string()), name.span());
         quote! { self.#field_name.send(::overwatch::services::life_cycle::LifecycleMessage::Kill)?; }
     });
 

--- a/overwatch-derive/src/utils.rs
+++ b/overwatch-derive/src/utils.rs
@@ -45,3 +45,7 @@ pub fn extract_type_from(ty: &Type) -> Type {
 pub fn field_name_to_type_name(name: &str) -> String {
     name.to_case(Case::Pascal)
 }
+
+pub fn enum_variant_name_to_field_name(name: &str) -> String {
+    name.to_case(Case::Snake)
+}

--- a/overwatch/src/overwatch/life_cycle.rs
+++ b/overwatch/src/overwatch/life_cycle.rs
@@ -5,13 +5,28 @@ use crate::services::life_cycle::FinishedSignal;
 pub trait ServicesLifeCycleHandle<RuntimeServiceId> {
     type Error;
 
+    /// Shut down a service.
+    ///
+    /// # Errors
+    ///
+    /// If the shutdown fails.
     fn shutdown(
         &self,
         service: &RuntimeServiceId,
         sender: Sender<FinishedSignal>,
     ) -> Result<(), Self::Error>;
 
+    /// Kill a service.
+    ///
+    /// # Errors
+    ///
+    /// If the kill fails.
     fn kill(&self, service: &RuntimeServiceId) -> Result<(), Self::Error>;
 
+    /// Kill all services.
+    ///
+    /// # Errors
+    ///
+    /// If the kill fails.
     fn kill_all(&self) -> Result<(), Self::Error>;
 }

--- a/overwatch/src/overwatch/life_cycle.rs
+++ b/overwatch/src/overwatch/life_cycle.rs
@@ -1,119 +1,17 @@
-use std::{
-    borrow::Cow, collections::HashMap, default::Default, error::Error, fmt::Display, hash::Hash,
-};
-
 use tokio::sync::broadcast::Sender;
 
-use crate::{
-    services::life_cycle::{FinishedSignal, LifecycleHandle, LifecycleMessage},
-    DynError,
-};
+use crate::services::life_cycle::FinishedSignal;
 
-/// Grouper handle for the [`LifecycleHandle`] of each spawned service.
-#[derive(Clone)]
-pub struct ServicesLifeCycleHandle<RuntimeServiceId> {
-    handlers: HashMap<RuntimeServiceId, LifecycleHandle>,
-}
+pub trait ServicesLifeCycleHandle<RuntimeServiceId> {
+    type Error;
 
-impl<RuntimeServiceId> ServicesLifeCycleHandle<RuntimeServiceId> {
-    #[must_use]
-    pub fn empty() -> Self {
-        Self {
-            handlers: HashMap::default(),
-        }
-    }
-
-    /// Get all [`ServiceId`]s registered in this handle
-    pub fn services_ids(&self) -> impl Iterator<Item = &RuntimeServiceId> {
-        self.handlers.keys()
-    }
-}
-
-impl<RuntimeServiceId> ServicesLifeCycleHandle<RuntimeServiceId>
-where
-    RuntimeServiceId: Eq + Hash,
-{
-    /// Send a `Shutdown` message to the specified service.
-    ///
-    /// # Arguments
-    ///
-    /// `service` - The [`ServiceId`] of the target service
-    /// `sender` - The sender side of a broadcast channel. It's expected that
-    /// once the receiver finishes processing the message, a signal will be
-    /// sent back.
-    ///
-    /// # Errors
-    ///
-    /// The error returned when trying to send the shutdown command to the
-    /// specified service.
-    ///
-    /// # Panics
-    /// If the specified service handler is not available.
-    pub fn shutdown(
+    fn shutdown(
         &self,
         service: &RuntimeServiceId,
         sender: Sender<FinishedSignal>,
-    ) -> Result<(), DynError> {
-        self.handlers
-            .get(service)
-            .expect("Map populated from macro, so service always exists.")
-            .send(LifecycleMessage::Shutdown(sender))?;
-        Ok(())
-    }
+    ) -> Result<(), Self::Error>;
 
-    /// Send a [`LifecycleMessage::Kill`] message to the specified service
-    /// ([`ServiceId`]) [`crate::overwatch::OverwatchRunner`].
-    /// # Arguments
-    ///
-    /// `service` - The [`ServiceId`] of the target service
-    ///
-    /// # Errors
-    ///
-    /// The error returned when trying to send the kill command to the specified
-    /// service.
-    ///
-    /// # Panics
-    /// If the specified service handler is not available.
-    pub fn kill(&self, service: &RuntimeServiceId) -> Result<(), DynError> {
-        self.handlers
-            .get(service)
-            .expect("Map populated from macro, so service always exists.")
-            .send(LifecycleMessage::Kill)
-    }
+    fn kill(&self, service: &RuntimeServiceId) -> Result<(), Self::Error>;
 
-    /// Send a [`LifecycleMessage::Kill`] message to all services registered in
-    /// this handle.
-    ///
-    /// # Errors
-    ///
-    /// The error returned when trying to send the kill command to any of the
-    /// running services.
-    pub fn kill_all(&self) -> Result<(), DynError> {
-        for service_id in self.services_ids() {
-            self.kill(service_id)?;
-        }
-        Ok(())
-    }
-}
-
-impl<const N: usize, RuntimeServiceId> TryFrom<[(RuntimeServiceId, LifecycleHandle); N]>
-    for ServicesLifeCycleHandle<RuntimeServiceId>
-where
-    RuntimeServiceId: Eq + Hash + Display,
-{
-    // TODO: On errors refactor extract into a concrete error type with `thiserror`
-    type Error = Box<dyn Error + Send + Sync>;
-
-    fn try_from(value: [(RuntimeServiceId, LifecycleHandle); N]) -> Result<Self, Self::Error> {
-        let mut handlers = HashMap::new();
-        for (service_id, handle) in value {
-            if handlers.contains_key(&service_id) {
-                return Err(Box::<dyn Error + Send + Sync>::from(Cow::Owned(format!(
-                    "Duplicated serviceId: {service_id}"
-                ))));
-            }
-            handlers.insert(service_id, handle);
-        }
-        Ok(Self { handlers })
-    }
+    fn kill_all(&self) -> Result<(), Self::Error>;
 }

--- a/overwatch/src/overwatch/mod.rs
+++ b/overwatch/src/overwatch/mod.rs
@@ -19,7 +19,6 @@ use tokio::{
 use tracing::instrument;
 use tracing::{error, info};
 
-pub use crate::overwatch::life_cycle::ServicesLifeCycleHandle;
 use crate::{
     overwatch::{
         commands::{
@@ -65,6 +64,8 @@ pub trait Services: Sized {
 
     type RuntimeServiceId;
 
+    type ServicesLifeCycleHandle;
+
     /// Spawn a new instance of the [`Services`] object.
     ///
     /// It returns a `(ServiceId, Runtime)` where Runtime is the [`Runtime`]
@@ -94,7 +95,7 @@ pub trait Services: Sized {
     /// # Errors
     ///
     /// The generated [`Error`].
-    fn start_all(&mut self) -> Result<ServicesLifeCycleHandle<Self::RuntimeServiceId>, Error>;
+    fn start_all(&mut self) -> Result<Self::ServicesLifeCycleHandle, Error>;
 
     /// Stop a service attached to the trait implementer.
     fn stop(&mut self, service_id: &Self::RuntimeServiceId);

--- a/overwatch/src/services/handle.rs
+++ b/overwatch/src/services/handle.rs
@@ -179,7 +179,7 @@ where
     /// # Errors
     ///
     /// If the service cannot be initialized properly with the retrieved state.
-    pub fn run<Service>(self) -> Result<(RuntimeServiceId, LifecycleHandle), crate::DynError>
+    pub fn run<Service>(self) -> Result<LifecycleHandle, crate::DynError>
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + RuntimeServiceIdTrait<RuntimeServiceId>
@@ -199,6 +199,6 @@ where
         runtime.spawn(service.run());
         runtime.spawn(state_handle.run());
 
-        Ok((Service::SERVICE_ID, lifecycle_handle))
+        Ok(lifecycle_handle)
     }
 }


### PR DESCRIPTION
Remove the runtime-populated and runtime-checked `ServicesLifeCycleHandle` type, in favour of a runtime-time populated but compile-time checked `RuntimeLifeCycleHandlers` type, which implements the newly introduced `ServicesLifeCycleHandle` trait, which exposes some of the methods the old type used to expose.