### PR TITLE
chore(service): Add bounds to internal types

### DIFF
--- a/examples/ping_pong/src/operators.rs
+++ b/examples/ping_pong/src/operators.rs
@@ -11,11 +11,11 @@ pub struct StateSaveOperator {
 
 #[async_trait::async_trait]
 impl StateOperator for StateSaveOperator {
-    type StateInput = PingState;
+    type State = PingState;
     type Settings = PingSettings;
     type LoadError = std::io::Error;
 
-    fn try_load(settings: &Self::Settings) -> Result<Option<Self::StateInput>, Self::LoadError> {
+    fn try_load(settings: &Self::Settings) -> Result<Option<Self::State>, Self::LoadError> {
         let state_string = std::fs::read_to_string(&settings.state_save_path)?;
         serde_json::from_str(&state_string)
             .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
@@ -27,7 +27,7 @@ impl StateOperator for StateSaveOperator {
         }
     }
 
-    async fn run(&mut self, state: Self::StateInput) {
+    async fn run(&mut self, state: Self::State) {
         let json_state = serde_json::to_string(&state).expect("Failed to serialize state");
         std::fs::write(&self.save_path, json_state).unwrap();
     }

--- a/examples/ping_pong/src/operators.rs
+++ b/examples/ping_pong/src/operators.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
-use overwatch::services::state::StateOperator;
+use overwatch::services::state::{ServiceState, StateOperator};
 
-use crate::{settings::PingSettings, states::PingState};
+use crate::states::PingState;
 
 #[derive(Debug, Clone)]
 pub struct StateSaveOperator {
@@ -12,18 +12,19 @@ pub struct StateSaveOperator {
 #[async_trait::async_trait]
 impl StateOperator for StateSaveOperator {
     type State = PingState;
-    type Settings = PingSettings;
     type LoadError = std::io::Error;
 
-    fn try_load(settings: &Self::Settings) -> Result<Option<Self::State>, Self::LoadError> {
+    fn try_load(
+        settings: &<Self::State as ServiceState>::Settings,
+    ) -> Result<Option<Self::State>, Self::LoadError> {
         let state_string = std::fs::read_to_string(&settings.state_save_path)?;
         serde_json::from_str(&state_string)
             .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
     }
 
-    fn from_settings(settings: Self::Settings) -> Self {
+    fn from_settings(settings: &<Self::State as ServiceState>::Settings) -> Self {
         Self {
-            save_path: settings.state_save_path,
+            save_path: settings.state_save_path.clone(),
         }
     }
 

--- a/examples/ping_pong/src/service_pong.rs
+++ b/examples/ping_pong/src/service_pong.rs
@@ -19,7 +19,7 @@ impl ServiceData for PongService {
     const SERVICE_ID: ServiceId = "pong";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = PongMessage;
 }
 

--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -118,6 +118,10 @@ impl OverwatchHandle {
 
     /// Send an overwatch command to the
     /// [`OverwatchRunner`](crate::overwatch::OverwatchRunner)
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs while trying to send the command.
     #[cfg_attr(
         feature = "instrumentation",
         instrument(name = "overwatch-command-send", skip(self))

--- a/overwatch/src/services/handle.rs
+++ b/overwatch/src/services/handle.rs
@@ -72,7 +72,7 @@ where
         relay_buffer_size: usize,
     ) -> Result<Self, State::Error>
     where
-        StateOp: StateOperator<Settings = Settings, StateInput = State>,
+        StateOp: StateOperator<Settings = Settings, State = State>,
     {
         let initial_state = if let Ok(Some(loaded_state)) = StateOp::try_load(&settings) {
             info!("Loaded state from Operator");
@@ -162,7 +162,7 @@ where
 impl<Message, Settings, State, StateOp> ServiceRunner<Message, Settings, State, StateOp>
 where
     State: Clone + Send + Sync + 'static,
-    StateOp: StateOperator<StateInput = State> + Send + 'static,
+    StateOp: StateOperator<State = State> + Send + 'static,
 {
     /// Spawn the service main loop and handle its lifecycle.
     ///

--- a/overwatch/src/services/handle.rs
+++ b/overwatch/src/services/handle.rs
@@ -72,7 +72,7 @@ where
         relay_buffer_size: usize,
     ) -> Result<Self, State::Error>
     where
-        StateOp: StateOperator<Settings = Settings, State = State>,
+        StateOp: StateOperator<State = State>,
     {
         let initial_state = if let Ok(Some(loaded_state)) = StateOp::try_load(&settings) {
             info!("Loaded state from Operator");
@@ -126,7 +126,7 @@ where
     /// Build a runner for this service
     pub fn service_runner<StateOp>(&mut self) -> ServiceRunner<Message, Settings, State, StateOp>
     where
-        StateOp: StateOperator<Settings = Settings>,
+        StateOp: StateOperator<State = State>,
     {
         // TODO: Add proper status handling here.
         // A service should be able to produce a runner if it is already running.
@@ -135,7 +135,7 @@ where
         // Add relay channel to handle
         self.outbound_relay = Some(outbound_relay);
         let settings = self.settings.notifier().get_updated_settings();
-        let operator = StateOp::from_settings(settings);
+        let operator = StateOp::from_settings(&settings);
         let (state_handle, state_updater) =
             StateHandle::<State, StateOp>::new(self.initial_state.clone(), operator);
 

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -7,7 +7,7 @@ pub mod status;
 
 use async_trait::async_trait;
 use handle::ServiceStateHandle;
-use state::ServiceState;
+use state::{ServiceState, StateOperator};
 
 // TODO: Make this type unique for each service?
 /// Services identification type.
@@ -23,9 +23,9 @@ pub trait ServiceData {
     /// Service settings object
     type Settings;
     /// Service state object
-    type State;
+    type State: ServiceState<Settings = Self::Settings>;
     /// State operator
-    type StateOperator;
+    type StateOperator: StateOperator<StateInput = Self::State, Settings = Self::Settings>;
     /// Service messages that the service itself understands and can react to
     type Message;
 }

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -23,9 +23,9 @@ pub trait ServiceData {
     /// Service settings object
     type Settings;
     /// Service state object
-    type State: ServiceState<Settings = Self::Settings>;
+    type State;
     /// State operator
-    type StateOperator: StateOperator<State = Self::State>;
+    type StateOperator;
     /// Service messages that the service itself understands and can react to
     type Message;
 }

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -25,7 +25,7 @@ pub trait ServiceData {
     /// Service state object
     type State: ServiceState<Settings = Self::Settings>;
     /// State operator
-    type StateOperator: StateOperator<State = Self::State, Settings = Self::Settings>;
+    type StateOperator: StateOperator<State = Self::State>;
     /// Service messages that the service itself understands and can react to
     type Message;
 }

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -25,7 +25,7 @@ pub trait ServiceData {
     /// Service state object
     type State: ServiceState<Settings = Self::Settings>;
     /// State operator
-    type StateOperator: StateOperator<StateInput = Self::State, Settings = Self::Settings>;
+    type StateOperator: StateOperator<State = Self::State, Settings = Self::Settings>;
     /// Service messages that the service itself understands and can react to
     type Message;
 }

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -7,7 +7,7 @@ pub mod status;
 
 use async_trait::async_trait;
 use handle::ServiceStateHandle;
-use state::{ServiceState, StateOperator};
+use state::ServiceState;
 
 // TODO: Make this type unique for each service?
 /// Services identification type.

--- a/overwatch/src/services/state.rs
+++ b/overwatch/src/services/state.rs
@@ -17,7 +17,8 @@ use tracing::error;
 pub trait ServiceState: Sized {
     /// Settings object that the state can be initialized from
     ///
-    /// In the standard use case - [`ServiceData::State`](crate::ServiceData::State) - it needs to
+    /// In the standard use case -
+    /// [`ServiceData::State`](crate::ServiceData::State) - it needs to
     /// match [`ServiceData::Settings`](crate::ServiceData::Settings).
     type Settings;
 
@@ -43,8 +44,8 @@ pub trait StateOperator {
     /// The type of state that the operator can handle.
     ///
     /// In the standard use case -
-    /// [`ServiceData::StateOperator`](crate::ServiceData::StateOperator) - it needs to match
-    /// [`ServiceData::State`](crate::ServiceData::State).
+    /// [`ServiceData::StateOperator`](crate::ServiceData::StateOperator) - it
+    /// needs to match [`ServiceData::State`](crate::ServiceData::State).
     type State: ServiceState;
 
     /// Errors that can occur during state loading.

--- a/overwatch/src/services/state.rs
+++ b/overwatch/src/services/state.rs
@@ -17,8 +17,8 @@ use tracing::error;
 pub trait ServiceState: Sized {
     /// Settings object that the state can be initialized from
     ///
-    /// Needs to match [`ServiceData::Settings`](crate::ServiceData::Settings)'s
-    /// [`ServiceState::Settings`].
+    /// In the standard use case - [`ServiceData::State`](crate::ServiceData::State) - it needs to
+    /// match [`ServiceData::Settings`](crate::ServiceData::Settings).
     type Settings;
 
     /// Errors that can occur during state initialization
@@ -42,8 +42,9 @@ pub trait ServiceState: Sized {
 pub trait StateOperator {
     /// The type of state that the operator can handle.
     ///
-    /// Needs to match [`ServiceData::State`](crate::ServiceData::State)'s
-    /// [`ServiceState::State`].
+    /// In the standard use case -
+    /// [`ServiceData::StateOperator`](crate::ServiceData::StateOperator) - it needs to match
+    /// [`ServiceData::State`](crate::ServiceData::State).
     type State: ServiceState;
 
     /// Errors that can occur during state loading.

--- a/overwatch/tests/cancelable_service.rs
+++ b/overwatch/tests/cancelable_service.rs
@@ -25,7 +25,7 @@ impl ServiceData for CancellableService {
     const SERVICE_ID: ServiceId = "cancel-me-please";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = NoMessage;
 }
 

--- a/overwatch/tests/generics.rs
+++ b/overwatch/tests/generics.rs
@@ -25,7 +25,7 @@ impl ServiceData for GenericService {
     const SERVICE_ID: ServiceId = "FooService";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = GenericServiceMessage;
 }
 

--- a/overwatch/tests/print_service.rs
+++ b/overwatch/tests/print_service.rs
@@ -24,7 +24,7 @@ impl ServiceData for PrintService {
     const SERVICE_ID: ServiceId = "FooService";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = PrintServiceMessage;
 }
 

--- a/overwatch/tests/sequence.rs
+++ b/overwatch/tests/sequence.rs
@@ -28,7 +28,7 @@ impl ServiceData for AwaitService1 {
     const SERVICE_ID: ServiceId = "S1";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = NoMessage;
 }
 
@@ -36,7 +36,7 @@ impl ServiceData for AwaitService2 {
     const SERVICE_ID: ServiceId = "S2";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = NoMessage;
 }
 
@@ -44,7 +44,7 @@ impl ServiceData for AwaitService3 {
     const SERVICE_ID: ServiceId = "S3";
     type Settings = ();
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = NoMessage;
 }
 

--- a/overwatch/tests/settings_update.rs
+++ b/overwatch/tests/settings_update.rs
@@ -25,7 +25,7 @@ impl ServiceData for SettingsService {
     const SERVICE_ID: ServiceId = "FooService";
     type Settings = SettingsServiceSettings;
     type State = NoState<Self::Settings>;
-    type StateOperator = NoOperator<Self::State, Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
     type Message = SettingsMsg;
 }
 

--- a/overwatch/tests/state_handling.rs
+++ b/overwatch/tests/state_handling.rs
@@ -53,7 +53,6 @@ pub struct CounterStateOperator;
 #[async_trait]
 impl StateOperator for CounterStateOperator {
     type State = CounterState;
-    type Settings = ();
     type LoadError = Infallible;
 
     fn try_load(
@@ -62,7 +61,7 @@ impl StateOperator for CounterStateOperator {
         Ok(None)
     }
 
-    fn from_settings(_settings: <Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
         Self
     }
 

--- a/overwatch/tests/state_handling.rs
+++ b/overwatch/tests/state_handling.rs
@@ -52,21 +52,21 @@ pub struct CounterStateOperator;
 
 #[async_trait]
 impl StateOperator for CounterStateOperator {
-    type StateInput = CounterState;
+    type State = CounterState;
     type Settings = ();
     type LoadError = Infallible;
 
     fn try_load(
-        _settings: &<Self::StateInput as ServiceState>::Settings,
-    ) -> Result<Option<Self::StateInput>, Self::LoadError> {
+        _settings: &<Self::State as ServiceState>::Settings,
+    ) -> Result<Option<Self::State>, Self::LoadError> {
         Ok(None)
     }
 
-    fn from_settings(_settings: <Self::StateInput as ServiceState>::Settings) -> Self {
+    fn from_settings(_settings: <Self::State as ServiceState>::Settings) -> Self {
         Self
     }
 
-    async fn run(&mut self, state: Self::StateInput) {
+    async fn run(&mut self, state: Self::State) {
         let value = state.value;
         let mut stdout = io::stdout();
         stdout

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -33,7 +33,6 @@ struct TryLoadOperator;
 #[async_trait]
 impl StateOperator for TryLoadOperator {
     type State = TryLoadState;
-    type Settings = TryLoadSettings;
     type LoadError = SendError<String>;
 
     fn try_load(
@@ -45,7 +44,7 @@ impl StateOperator for TryLoadOperator {
         Ok(Some(Self::State {}))
     }
 
-    fn from_settings(_settings: <Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
         Self {}
     }
 

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -32,24 +32,24 @@ struct TryLoadOperator;
 
 #[async_trait]
 impl StateOperator for TryLoadOperator {
-    type StateInput = TryLoadState;
+    type State = TryLoadState;
     type Settings = TryLoadSettings;
     type LoadError = SendError<String>;
 
     fn try_load(
-        settings: &<Self::StateInput as ServiceState>::Settings,
-    ) -> Result<Option<Self::StateInput>, Self::LoadError> {
+        settings: &<Self::State as ServiceState>::Settings,
+    ) -> Result<Option<Self::State>, Self::LoadError> {
         settings
             .origin_sender
             .send(String::from("StateOperator::try_load"))?;
-        Ok(Some(Self::StateInput {}))
+        Ok(Some(Self::State {}))
     }
 
-    fn from_settings(_settings: <Self::StateInput as ServiceState>::Settings) -> Self {
+    fn from_settings(_settings: <Self::State as ServiceState>::Settings) -> Self {
         Self {}
     }
 
-    async fn run(&mut self, _state: Self::StateInput) {}
+    async fn run(&mut self, _state: Self::State) {}
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Restrict `ServiceData`'s `State` and `StateOperator`, as they are the only valid options for the `Service` to function correctly. While the bounds themselves do not add extra value—since they are already inferred by the compiler from other parts of the code—explicitly specifying them improves understandability.

The decision to use associated types instead of generics is driven by the fact that `State` and `StateOperator` generally operate on a single type. If support for multiple types is needed, users can work around this by assigning a generic type to the associated type.

Closes: https://github.com/logos-co/Overwatch/issues/59