### PR TITLE
feat: re-introduce service names for service-local tracing

### DIFF
--- a/examples/ping_pong/src/service_ping.rs
+++ b/examples/ping_pong/src/service_ping.rs
@@ -21,6 +21,7 @@ pub struct PingService {
 }
 
 impl ServiceData for PingService {
+    const SERVICE_NAME: &'static str = "ping";
     type Settings = PingSettings;
     type State = PingState;
     type StateOperator = StateSaveOperator;

--- a/examples/ping_pong/src/service_pong.rs
+++ b/examples/ping_pong/src/service_pong.rs
@@ -17,6 +17,7 @@ pub struct PongService {
 }
 
 impl ServiceData for PongService {
+    const SERVICE_NAME: &'static str = "pong";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/Cargo.toml
+++ b/overwatch/Cargo.toml
@@ -20,6 +20,7 @@ instrumentation = []
 
 [dependencies]
 async-trait      = "0.1"
+const-str        = "0.6"
 futures          = "0.3"
 overwatch-derive = { workspace = true, optional = true }
 thiserror        = "2.0"

--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{Debug, Display},
-    marker::PhantomData,
-};
+use std::{fmt::Debug, marker::PhantomData};
 
 use tokio::{
     runtime::Handle,
@@ -58,7 +55,7 @@ impl<RuntimeServiceId> OverwatchHandle<RuntimeServiceId> {
 
 impl<RuntimeServiceId> OverwatchHandle<RuntimeServiceId>
 where
-    RuntimeServiceId: Display + Debug + Sync,
+    RuntimeServiceId: Debug + Sync,
 {
     /// Request a relay with a service
     pub async fn relay<Service>(&self) -> Result<OutboundRelay<Service::Message>, RelayError>
@@ -66,7 +63,7 @@ where
         Service: RuntimeServiceIdTrait<RuntimeServiceId>,
         Service::Message: 'static,
     {
-        info!("Requesting relay with {}", Service::SERVICE_ID);
+        info!("Requesting relay with {}", Service::SERVICE_NAME);
         let (sender, receiver) = tokio::sync::oneshot::channel();
 
         let Ok(()) = self
@@ -95,7 +92,7 @@ where
     where
         Service: RuntimeServiceIdTrait<RuntimeServiceId>,
     {
-        info!("Requesting status watcher for {}", Service::SERVICE_ID);
+        info!("Requesting status watcher for {}", Service::SERVICE_NAME);
         let (sender, receiver) = tokio::sync::oneshot::channel();
         let Ok(()) = self
             .send(OverwatchCommand::Status(StatusCommand {
@@ -109,16 +106,11 @@ where
         receiver.await.unwrap_or_else(|_| {
             panic!(
                 "Service {} watcher should always be available",
-                Service::SERVICE_ID
+                Service::SERVICE_NAME
             )
         })
     }
-}
 
-impl<RuntimeServiceId> OverwatchHandle<RuntimeServiceId>
-where
-    RuntimeServiceId: Debug + Sync,
-{
     /// Send a shutdown signal to the
     /// [`OverwatchRunner`](crate::overwatch::OverwatchRunner)
     pub async fn shutdown(&self) {

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -12,6 +12,8 @@ use state::ServiceState;
 /// The core data a service needs to handle.
 /// Holds the necessary information of a service.
 pub trait ServiceData {
+    /// Service identification tag for tracing purposes
+    const SERVICE_NAME: &'static str;
     /// Service relay buffer size
     const SERVICE_RELAY_BUFFER_SIZE: usize = 16;
     /// Service settings object

--- a/overwatch/src/utils/const_checks.rs
+++ b/overwatch/src/utils/const_checks.rs
@@ -1,0 +1,34 @@
+#[must_use]
+pub const fn unique_ids(to_check: &[&'static str]) -> bool {
+    if to_check.is_empty() {
+        return true;
+    }
+    let mut i: usize = 0;
+    let mut j: usize = 1;
+    while i < to_check.len() - 1 {
+        if const_str::equal!(to_check[i], to_check[j]) {
+            return false;
+        }
+        j += 1;
+        if j >= to_check.len() {
+            i += 1;
+            j = i + 1;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod test {
+    use crate::utils::const_checks::unique_ids;
+
+    #[test]
+    const fn test_unique_ids() {
+        // This shouldn't even compile if checks fails
+        const _: () = assert!(unique_ids(&["A", "B"]));
+        const _: () = assert!(!unique_ids(&["A", "A"]));
+
+        const _: () = assert!(unique_ids(&[]));
+        const _: () = assert!(unique_ids(&["A"]));
+    }
+}

--- a/overwatch/src/utils/mod.rs
+++ b/overwatch/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod const_checks;
 pub mod runtime;

--- a/overwatch/tests/cancelable_service.rs
+++ b/overwatch/tests/cancelable_service.rs
@@ -21,6 +21,7 @@ pub struct CancellableService {
 }
 
 impl ServiceData for CancellableService {
+    const SERVICE_NAME: &'static str = "cancel-me-please";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/tests/generics.rs
+++ b/overwatch/tests/generics.rs
@@ -21,6 +21,7 @@ pub struct GenericService {
 pub struct GenericServiceMessage(String);
 
 impl ServiceData for GenericService {
+    const SERVICE_NAME: &'static str = "FooService";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/tests/print_service.rs
+++ b/overwatch/tests/print_service.rs
@@ -21,6 +21,7 @@ pub struct PrintService {
 pub struct PrintServiceMessage(String);
 
 impl ServiceData for PrintService {
+    const SERVICE_NAME: &'static str = "FooService";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/tests/sequence.rs
+++ b/overwatch/tests/sequence.rs
@@ -24,6 +24,7 @@ pub struct AwaitService3 {
 }
 
 impl ServiceData for AwaitService1 {
+    const SERVICE_NAME: &'static str = "S1";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;
@@ -31,6 +32,7 @@ impl ServiceData for AwaitService1 {
 }
 
 impl ServiceData for AwaitService2 {
+    const SERVICE_NAME: &'static str = "S2";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;
@@ -38,6 +40,7 @@ impl ServiceData for AwaitService2 {
 }
 
 impl ServiceData for AwaitService3 {
+    const SERVICE_NAME: &'static str = "S3";
     type Settings = ();
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/tests/settings_update.rs
+++ b/overwatch/tests/settings_update.rs
@@ -22,6 +22,7 @@ type SettingsServiceSettings = String;
 pub struct SettingsMsg;
 
 impl ServiceData for SettingsService {
+    const SERVICE_NAME: &'static str = "FooService";
     type Settings = SettingsServiceSettings;
     type State = NoState<Self::Settings>;
     type StateOperator = NoOperator<Self::State, Self::Settings>;

--- a/overwatch/tests/state_handling.rs
+++ b/overwatch/tests/state_handling.rs
@@ -78,6 +78,7 @@ impl StateOperator for CounterStateOperator {
 }
 
 impl ServiceData for UpdateStateService {
+    const SERVICE_NAME: &'static str = "FooService";
     type Settings = ();
     type State = CounterState;
     type StateOperator = CounterStateOperator;

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -62,6 +62,7 @@ struct TryLoad {
 }
 
 impl ServiceData for TryLoad {
+    const SERVICE_NAME: &'static str = "try_load";
     type Settings = TryLoadSettings;
     type State = TryLoadState;
     type StateOperator = TryLoadOperator;


### PR DESCRIPTION
The current design does not work with the `should_stop_service` function in nomos, since the `ServiceId` is implemented by the runtime, hence each service does not know it implements it, and compilation fails. I had to re-introduce uniqueness checks and a `SERVICE_NAME` value on `ServiceData` which is a hard-coded string and used for tracing. This is all the service is concerned. The `ServiceId` trait of course still provides all the compile-time guarantees.