### PR TITLE
chore: update Rust to 1.85.1

### DIFF
--- a/.github/rust_update_issue_template.md
+++ b/.github/rust_update_issue_template.md
@@ -1,0 +1,5 @@
+---
+title: "[CI GENERATED] Update Rust to version {{ env.RUST_VERSION }}"
+labels: "ci-actions"
+---
+Update Rust to version {{ env.RUST_VERSION }}.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.85.1"


### PR DESCRIPTION
It also fixes the broken CI pipeline for the new version check.