### PR TITLE
fix: preserve field attributes when expanding macro

### DIFF
--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -77,6 +77,7 @@ pub fn derive_services(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let modified_fields = fields.iter().map(|field| {
         let field_name = &field.ident;
         let field_type = &field.ty;
+        let field_attrs = &field.attrs; // Preserve attributes (including feature flags)
 
         let runtime_service_id_type_name = get_runtime_service_id_type_name();
         let new_field_type = quote! {
@@ -84,6 +85,7 @@ pub fn derive_services(_attr: TokenStream, item: TokenStream) -> TokenStream {
         };
 
         quote! {
+            #(#field_attrs)*
             #field_name: #new_field_type
         }
     });


### PR DESCRIPTION
Bug found when trying to expand macro for `nomos-executor`. While the `derive` macro preserved all struct properties, a procedural macro does not. I think the only thing we should propagate are the field attributes like feature-gated properties, which is the case now.