### PR TITLE
chore: update to Rust 1.86 and fix broken CI version check workflow

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746  # Version 1.0.6
         with:
-          toolchain: nightly-2025-01-03
+          toolchain: nightly-2025-02-16
           profile: minimal
           components: rustfmt
           override: true

--- a/.github/workflows/rust-latest-version-check.yml
+++ b/.github/workflows/rust-latest-version-check.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2  # Version 4.2.2
       - name: Create a GH issue (if it does not exist)
-        uses: JasonEtco/create-an-issue@56fdd2d6f960e970fa9d5ca3cf3884b6ba5af477 # Version 2.9.2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # Version 2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUST_VERSION: ${{ needs.check-latest-version.outputs.new-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v1.0
     hooks:
       - id: fmt
-        entry: cargo +nightly-2025-01-03 fmt
+        entry: cargo +nightly-2025-02-16 fmt
       - id: clippy
   - repo: https://github.com/EmbarkStudios/cargo-deny
     rev: 0.18.0

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-slim-bullseye
+FROM rust:1.86.0-slim-bullseye
 
 LABEL maintainer="augustinas@status.im"
 LABEL source="https://github.com/logos-co/Overwatch"

--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -57,7 +57,11 @@ impl<RuntimeServiceId> OverwatchHandle<RuntimeServiceId>
 where
     RuntimeServiceId: Debug + Sync + Display,
 {
-    /// Request a relay with a service
+    /// Request a relay with a service.
+    ///
+    /// # Errors
+    ///
+    /// If the relay cannot be created, or if the service is not available.
     pub async fn relay<Service>(&self) -> Result<OutboundRelay<Service::Message>, RelayError>
     where
         Service: ServiceData,

--- a/overwatch/src/services/status.rs
+++ b/overwatch/src/services/status.rs
@@ -74,6 +74,10 @@ impl StatusHandle {
         let watcher = StatusWatcher(watcher);
         Self { updater, watcher }
     }
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "We dereference an `Arc`, which is not const"
+    )]
     #[must_use]
     pub fn updater(&self) -> &StatusUpdater {
         &self.updater

--- a/overwatch/tests/cancelable_service.rs
+++ b/overwatch/tests/cancelable_service.rs
@@ -39,7 +39,6 @@ impl ServiceCore<RuntimeServiceId> for CancellableService {
     async fn run(self) -> Result<(), DynError> {
         let mut lifecycle_stream = self.service_state.lifecycle_handle.message_stream();
         let mut interval = tokio::time::interval(Duration::from_millis(200));
-        #[expect(clippy::redundant_pub_crate)]
         loop {
             tokio::select! {
                 msg = lifecycle_stream.next() => {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # Keep this version in sync also in the following places:
 # * ci/Dockerfile
 # * shell.nix
-channel = "1.85.1"
+channel = "1.86.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,7 @@
 # Keep this version in sync also in the following places:
 # * ci/Dockerfile
 # * shell.nix
+# Also, update the version of the nightly toolchain to the latest nightly of the new version specified in the following places:
+# * workflows/code-check.yml (fmt job)
+# * .pre-commit-config.yml (fmt hook)
 channel = "1.86.0"

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@
     overlays = [
       (import (fetchGit {
         url = "https://github.com/oxalica/rust-overlay.git";
-        rev = "a0e3395c63cdbc9c1ec17915f8328c077c79c4a1";
+        rev = "c4a8327b0f25d1d81edecbb6105f74d7cf9d7382";
       }))
     ];
    }
@@ -19,7 +19,7 @@ pkgs.mkShell {
     pkg-config
     # Updating the version here requires also updating the `rev` version in the `overlays` section above
     # with a commit that contains the new version in its manifest
-    rust-bin.stable."1.85.1".default
+    rust-bin.stable."1.86.0".default
     go_1_19
   ];
 }


### PR DESCRIPTION
New lints introduced: https://rust-lang.github.io/rust-clippy/master/index.html?versions=eq%3A86.