### PR TITLE
[DRAFT] Lost lifecycle message using broadcast channel

### DIFF
--- a/overwatch/src/overwatch/mod.rs
+++ b/overwatch/src/overwatch/mod.rs
@@ -247,6 +247,7 @@ where
                     Self::handle_status(&services, status_command);
                 }
                 OverwatchCommand::ServiceLifeCycle(msg) => {
+                    println!("[OverwatchRunner] ServiceLifeCycleCommand");
                     Self::handle_service_service_lifecycle(&services, msg);
                 }
                 OverwatchCommand::OverwatchLifeCycle(command) => match command {
@@ -322,12 +323,15 @@ where
                 service_id,
                 msg: start_msg @ LifecycleMessage::Start(_),
             } => {
+                println!("[OverwatchRunner] Start Msg");
                 if let Err(e) = services
                     .get_service_lifecycle_handle(&service_id)
                     .send(start_msg)
                 {
+                    println!("[OverwatchRunner] Error sending start message {e:?}");
                     error!(e);
                 }
+                println!("[OverwatchRunner] Start msg sent");
             }
             ServiceLifeCycleCommand {
                 service_id,
@@ -349,7 +353,7 @@ where
 pub struct Overwatch<RuntimeServiceId> {
     runtime: Runtime,
     handle: OverwatchHandle<RuntimeServiceId>,
-    finish_runner_signal: oneshot::Receiver<FinishOverwatchSignal>,
+    pub finish_runner_signal: oneshot::Receiver<FinishOverwatchSignal>,
 }
 
 impl<RuntimeServiceId> Overwatch<RuntimeServiceId> {

--- a/overwatch/src/services/life_cycle.rs
+++ b/overwatch/src/services/life_cycle.rs
@@ -45,6 +45,7 @@ pub struct LifecycleHandle {
 
 impl Clone for LifecycleHandle {
     fn clone(&self) -> Self {
+        println!("############## Cloned #############");
         Self {
             // `resubscribe` gives access only to newly produced events, not already enqueued ones.
             // This is acceptable for two reasons:


### PR DESCRIPTION
Seldomly, the lifecycle test will fail due to, apparently, a lost message. The `ServiceLifecycle::Start` message will be sent but not received at the other end.

The issue happens in the `test_lifecycle` test.

To reproduce, run the following command. After a while it will freeze:
`while cargo test test_lifecycle -- --nocapture; do :; done`