### PR TITLE
feature(lifecycle): Minor leftovers

### DIFF
--- a/overwatch/src/overwatch/commands.rs
+++ b/overwatch/src/overwatch/commands.rs
@@ -52,10 +52,10 @@ pub struct ServiceLifeCycleCommand<RuntimeServiceId> {
 // TODO: Due to the variant's names a broader `OverwatchCommand` might be more suitable.
 #[derive(Debug)]
 pub enum OverwatchLifeCycleCommand {
-    /// Starts all `Service`s associated to an
+    /// Starts all `Service`s associated with an
     /// [`Overwatch`](crate::overwatch::Overwatch) instance.
     StartAllServices,
-    /// Stops all `Service`s associated to an
+    /// Stops all `Service`s associated with an
     /// [`Overwatch`](crate::overwatch::Overwatch) instance.
     StopAllServices,
     /// Shuts down [`Overwatch`](crate::overwatch::Overwatch), sending the

--- a/overwatch/src/services/runner.rs
+++ b/overwatch/src/services/runner.rs
@@ -31,6 +31,10 @@ impl<Message, Settings, State, StateOperator>
     pub const fn runner_join_handle(&self) -> &JoinHandle<()> {
         &self.runner_join_handle
     }
+
+    pub fn runner_join_handle_owned(self) -> JoinHandle<()> {
+        self.runner_join_handle
+    }
 }
 
 /// Executor for a `Service`.

--- a/overwatch/src/services/runner.rs
+++ b/overwatch/src/services/runner.rs
@@ -288,9 +288,9 @@ where
         .await;
 
         service_resources
-            .retrieve_inbound_relay_consumer()
+            .rebuild_inbound_relay()
             .unwrap_or_else(|error| {
-                panic!("Failed to retrieve inbound relay consumer: {error}");
+                panic!("Could not rebuild the InboundRelay: {error}");
             });
 
         service_resources

--- a/overwatch/src/services/runner.rs
+++ b/overwatch/src/services/runner.rs
@@ -97,7 +97,7 @@ where
         StateOp: Clone,
     {
         let service_handle = ServiceHandle::from(&self.service_resources);
-        let runtime = self.service_resources.overwatch_handle.runtime().clone();
+        let runtime = self.service_resources.overwatch_handle().runtime().clone();
         let runner_join_handle = runtime.spawn(self.run_::<Service>());
 
         ServiceRunnerHandle {
@@ -121,7 +121,7 @@ where
         let mut service_task_handle: Option<_> = None;
         let mut state_handle_task_handle: Option<_> = None;
 
-        while let Some(lifecycle_message) = service_resources.lifecycle_handle.next().await {
+        while let Some(lifecycle_message) = service_resources.lifecycle_handle_mut().next().await {
             match lifecycle_message {
                 LifecycleMessage::Start(finished_signal_sender) => {
                     if service_lifecycle_phase == LifecyclePhase::Started {
@@ -189,12 +189,9 @@ where
             }
         };
 
-        let inbound_relay = service_resources
-            .inbound_relay
-            .take()
-            .expect("Failed to retrieve inbound relay.");
-
-        let service_resources_handle = service_resources.to_handle(inbound_relay);
+        let service_resources_handle = service_resources.as_handle().unwrap_or_else(|error| {
+            panic!("Failed to create the ServiceResourcesHandle: {error}");
+        });
         let service = Service::init(service_resources_handle, initial_state.clone());
 
         service_resources
@@ -202,7 +199,7 @@ where
             .update(Some(initial_state));
 
         service_resources
-            .status_handle
+            .status_handle()
             .service_runner_updater()
             .starting();
 
@@ -231,10 +228,10 @@ where
             + 'static,
         StateOp: StateOperator<State = State> + Clone,
     {
-        let runtime = service_resources.overwatch_handle.runtime().clone();
+        let runtime = service_resources.overwatch_handle().runtime().clone();
         let service_task = Self::create_service_run_task(service, service_resources);
         *service_task_handle = Some(runtime.spawn(service_task));
-        let state_handle_task = service_resources.state_handle.clone().run();
+        let state_handle_task = service_resources.state_handle().clone().run();
         *state_handle_task_handle = Some(runtime.spawn(state_handle_task));
     }
 
@@ -248,7 +245,7 @@ where
         StateOp: Clone,
     {
         let task = service.run();
-        let lifecycle_notifier = service_resources.lifecycle_handle.notifier().clone();
+        let lifecycle_notifier = service_resources.lifecycle_handle().notifier().clone();
 
         // Receiver is ignored because it's pointless:
         // - If we wait for it, the Stop message will eventually abort it before the
@@ -294,7 +291,7 @@ where
             });
 
         service_resources
-            .status_handle
+            .status_handle()
             .service_runner_updater()
             .stopped();
     }

--- a/overwatch/tests/lifecycle.rs
+++ b/overwatch/tests/lifecycle.rs
@@ -119,7 +119,7 @@ impl ServiceCore<RuntimeServiceId> for LifecycleService {
         } = self;
 
         let assert_sender = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings()
             .assert_sender;

--- a/overwatch/tests/on_stop.rs
+++ b/overwatch/tests/on_stop.rs
@@ -33,7 +33,7 @@ impl ServiceCore<RuntimeServiceId> for OnStopService {
         _initial_state: Self::State,
     ) -> Result<Self, DynError> {
         let settings = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings();
         Ok(Self {

--- a/overwatch/tests/settings_update.rs
+++ b/overwatch/tests/settings_update.rs
@@ -40,7 +40,7 @@ impl ServiceCore<RuntimeServiceId> for SettingsService {
     }
 
     async fn run(mut self) -> Result<(), overwatch::DynError> {
-        let settings_reader = self.service_resources_handle.settings_updater.notifier();
+        let settings_reader = self.service_resources_handle.settings_handle.notifier();
         let print = async move {
             let mut asserted = false;
             for _ in 0..10 {

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -86,7 +86,7 @@ impl ServiceCore<RuntimeServiceId> for TryLoad {
             ..
         } = self;
         let sender = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings()
             .origin_sender;


### PR DESCRIPTION
- Make teardown graceful
- Improve Relay aliases names
- Make ServiceResources attributes private and add getters
- Abstract `InboundRelay`'s receiver fetching into `ServiceResources
- Improve documentation

Merges after: https://github.com/logos-co/Overwatch/pull/79