### PR TITLE
feature(lifecycle): Rework SettingsUpdater into SettingsHandle.

### DIFF
--- a/overwatch/tests/lifecycle.rs
+++ b/overwatch/tests/lifecycle.rs
@@ -119,7 +119,7 @@ impl ServiceCore<RuntimeServiceId> for LifecycleService {
         } = self;
 
         let assert_sender = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings()
             .assert_sender;

--- a/overwatch/tests/on_stop.rs
+++ b/overwatch/tests/on_stop.rs
@@ -33,7 +33,7 @@ impl ServiceCore<RuntimeServiceId> for OnStopService {
         _initial_state: Self::State,
     ) -> Result<Self, DynError> {
         let settings = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings();
         Ok(Self {

--- a/overwatch/tests/settings_update.rs
+++ b/overwatch/tests/settings_update.rs
@@ -40,7 +40,7 @@ impl ServiceCore<RuntimeServiceId> for SettingsService {
     }
 
     async fn run(mut self) -> Result<(), overwatch::DynError> {
-        let settings_reader = self.service_resources_handle.settings_updater.notifier();
+        let settings_reader = self.service_resources_handle.settings_handle.notifier();
         let print = async move {
             let mut asserted = false;
             for _ in 0..10 {

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -86,7 +86,7 @@ impl ServiceCore<RuntimeServiceId> for TryLoad {
             ..
         } = self;
         let sender = service_resources_handle
-            .settings_updater
+            .settings_handle
             .notifier()
             .get_updated_settings()
             .origin_sender;


### PR DESCRIPTION
The new `SettingsHandle` mimics the way other handles are built, which lowers cognitive load and allows for cloning only the required component.

Merges after: https://github.com/logos-co/Overwatch/pull/79