### PR TITLE
chore(post-lifecycle): Refactor Overwatch's Services into its own module

### DIFF
--- a/overwatch/src/overwatch/mod.rs
+++ b/overwatch/src/overwatch/mod.rs
@@ -2,131 +2,23 @@ pub mod commands;
 pub mod errors;
 pub mod handle;
 pub mod runner;
+pub mod services;
 
 use std::{any::Any, future::Future};
 
-use async_trait::async_trait;
 pub use errors::{DynError, Error};
+pub use handle::OverwatchHandle;
 pub use runner::{GenericOverwatchRunner, OverwatchRunner, OVERWATCH_THREAD_NAME};
+pub use services::Services;
 use tokio::{
     runtime::{Handle, Runtime},
     task::JoinHandle,
 };
 
-use crate::{
-    overwatch::handle::OverwatchHandle,
-    services::{lifecycle::LifecycleNotifier, relay::AnyMessage, status::StatusWatcher},
-    utils::finished_signal,
-};
+use crate::utils::finished_signal;
 
 /// Marker trait for settings' related elements.
 pub type AnySettings = Box<dyn Any + Send>;
-
-/// An Overwatch may run anything that implements this trait.
-///
-/// An implementor of this trait would have to handle the inner.
-/// [`ServiceCore`](crate::services::ServiceCore).
-#[async_trait]
-pub trait Services: Sized {
-    /// Inner [`ServiceCore::Settings`](crate::services::ServiceCore) grouping
-    /// type.
-    ///
-    /// Normally this will be a settings object that groups all the inner
-    /// services settings.
-    type Settings;
-
-    /// The type aggregating all different services identifiers that are part of
-    /// this runtime implementation.
-    ///
-    /// This type is used by the services themselves to communicate with each
-    /// other and to verify whether two services are part of the same runtime.
-    type RuntimeServiceId;
-
-    /// Spawn a new instance of the [`Services`] object.
-    ///
-    /// It returns a `(ServiceId, Runtime)` where Runtime is the [`Runtime`]
-    /// attached for each service.
-    ///
-    /// It also returns an instance of the implementing type.
-    ///
-    /// # Errors
-    ///
-    /// The implementer's creation error.
-    fn new(
-        settings: Self::Settings,
-        overwatch_handle: OverwatchHandle<Self::RuntimeServiceId>,
-    ) -> Result<Self, DynError>;
-
-    /// Start a service attached to the trait implementer.
-    ///
-    /// # Errors
-    ///
-    /// The generated [`Error`](enum@Error).
-    async fn start(&mut self, service_id: &Self::RuntimeServiceId) -> Result<(), Error>;
-
-    /// Start all services attached to the trait implementer.
-    ///
-    /// # Errors
-    ///
-    /// The generated [`Error`](enum@Error).
-    async fn start_all(&mut self) -> Result<(), Error>;
-
-    /// Stop a service attached to the trait implementer.
-    ///
-    /// # Errors
-    ///
-    /// The generated [`Error`](enum@Error).
-    async fn stop(&mut self, service_id: &Self::RuntimeServiceId) -> Result<(), Error>;
-
-    /// Stop all services attached to the trait implementer.
-    ///
-    /// # Errors
-    ///
-    /// The generated [`Error`](enum@Error).
-    async fn stop_all(&mut self) -> Result<(), Error>;
-
-    /// Shuts down the `Service`'s
-    /// [`ServiceRunner`](crate::services::runner::ServiceRunner)s attached to
-    /// the trait implementer.
-    ///
-    /// Depending on the implementation, this may be a no-op.
-    ///
-    /// This is the opposite operation of [`Self::new`]: It's _final_.
-    /// `Service`s won't be able to be started again after calling it.
-    ///
-    /// # Note
-    ///
-    /// The current implementation of this function (when derived via the
-    /// [`#[derive_services]`](overwatch_derive::derive_services) macro)
-    /// kills the [`ServiceRunner`](crate::services::runner::ServiceRunner)s
-    /// without waiting for their respective `Service`s to finish.
-    /// If you want to wait for the `Service`s to finish, you should call
-    /// [`Self::stop_all`] first.
-    ///
-    /// # Errors
-    ///
-    /// The generated [`Error`](enum@Error).
-    async fn teardown(self) -> Result<(), Error>;
-
-    /// Request a communication relay for a service attached to the trait
-    /// implementer.
-    fn request_relay(&mut self, service_id: &Self::RuntimeServiceId) -> AnyMessage;
-
-    /// Request a status watcher for a service attached to the trait
-    /// implementer.
-    fn request_status_watcher(&self, service_id: &Self::RuntimeServiceId) -> StatusWatcher;
-
-    /// Update service settings for all services attached to the trait
-    /// implementer.
-    fn update_settings(&mut self, settings: Self::Settings);
-
-    /// Get the [`LifecycleNotifier`] for a service attached to the trait
-    /// implementer.
-    fn get_service_lifecycle_notifier(
-        &self,
-        service_id: &Self::RuntimeServiceId,
-    ) -> &LifecycleNotifier;
-}
 
 /// Main Overwatch entity.
 /// It manages the [`Runtime`] and [`OverwatchHandle`].
@@ -181,12 +73,12 @@ impl<RuntimeServiceId> Overwatch<RuntimeServiceId> {
 mod test {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use tokio::time::sleep;
 
-    use super::*;
     use crate::{
         overwatch::{handle::OverwatchHandle, Error, OverwatchRunner, Services},
-        services::{lifecycle::LifecycleNotifier, status::StatusWatcher},
+        services::{lifecycle::LifecycleNotifier, relay::AnyMessage, status::StatusWatcher},
     };
 
     struct EmptyServices;

--- a/overwatch/src/overwatch/services.rs
+++ b/overwatch/src/overwatch/services.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+
+use crate::{
+    overwatch::{handle::OverwatchHandle, Error},
+    services::{lifecycle::LifecycleNotifier, relay::AnyMessage, status::StatusWatcher},
+    DynError,
+};
+
+/// An Overwatch may run anything that implements this trait.
+///
+/// An implementor of this trait would have to handle the inner.
+/// [`ServiceCore`](crate::services::ServiceCore).
+#[async_trait]
+pub trait Services: Sized {
+    /// Inner [`ServiceCore::Settings`](crate::services::ServiceCore) grouping
+    /// type.
+    ///
+    /// Normally this will be a settings object that groups all the inner
+    /// services settings.
+    type Settings;
+
+    /// The type aggregating all different services identifiers that are part of
+    /// this runtime implementation.
+    ///
+    /// This type is used by the services themselves to communicate with each
+    /// other and to verify whether two services are part of the same runtime.
+    type RuntimeServiceId;
+
+    /// Spawn a new instance of the [`Services`] object.
+    ///
+    /// It returns a `(ServiceId, Runtime)` where Runtime is the
+    /// [`Runtime`](tokio::runtime::Runtime) attached for each service.
+    ///
+    /// It also returns an instance of the implementing type.
+    ///
+    /// # Errors
+    ///
+    /// The implementer's creation error.
+    fn new(
+        settings: Self::Settings,
+        overwatch_handle: OverwatchHandle<Self::RuntimeServiceId>,
+    ) -> Result<Self, DynError>;
+
+    /// Start a service attached to the trait implementer.
+    ///
+    /// # Errors
+    ///
+    /// The generated [`Error`](enum@Error).
+    async fn start(&mut self, service_id: &Self::RuntimeServiceId) -> Result<(), Error>;
+
+    /// Start all services attached to the trait implementer.
+    ///
+    /// # Errors
+    ///
+    /// The generated [`Error`](enum@Error).
+    async fn start_all(&mut self) -> Result<(), Error>;
+
+    /// Stop a service attached to the trait implementer.
+    ///
+    /// # Errors
+    ///
+    /// The generated [`Error`](enum@Error).
+    async fn stop(&mut self, service_id: &Self::RuntimeServiceId) -> Result<(), Error>;
+
+    /// Stop all services attached to the trait implementer.
+    ///
+    /// # Errors
+    ///
+    /// The generated [`Error`](enum@Error).
+    async fn stop_all(&mut self) -> Result<(), Error>;
+
+    /// Shuts down the `Service`'s
+    /// [`ServiceRunner`](crate::services::runner::ServiceRunner)s attached to
+    /// the trait implementer.
+    ///
+    /// Depending on the implementation, this may be a no-op.
+    ///
+    /// This is the opposite operation of [`Self::new`]: It's _final_.
+    /// `Service`s won't be able to be started again after calling it.
+    ///
+    /// # Note
+    ///
+    /// The current implementation of this function (when derived via the
+    /// [`#[derive_services]`](overwatch_derive::derive_services) macro)
+    /// kills the [`ServiceRunner`](crate::services::runner::ServiceRunner)s
+    /// without waiting for their respective `Service`s to finish.
+    /// If you want to wait for the `Service`s to finish, you should call
+    /// [`Self::stop_all`] first.
+    ///
+    /// # Errors
+    ///
+    /// The generated [`Error`](enum@Error).
+    async fn teardown(self) -> Result<(), Error>;
+
+    /// Request a communication relay for a service attached to the trait
+    /// implementer.
+    fn request_relay(&mut self, service_id: &Self::RuntimeServiceId) -> AnyMessage;
+
+    /// Request a status watcher for a service attached to the trait
+    /// implementer.
+    fn request_status_watcher(&self, service_id: &Self::RuntimeServiceId) -> StatusWatcher;
+
+    /// Update service settings for all services attached to the trait
+    /// implementer.
+    fn update_settings(&mut self, settings: Self::Settings);
+
+    /// Get the [`LifecycleNotifier`] for a service attached to the trait
+    /// implementer.
+    fn get_service_lifecycle_notifier(
+        &self,
+        service_id: &Self::RuntimeServiceId,
+    ) -> &LifecycleNotifier;
+}


### PR DESCRIPTION
Merges after: https://github.com/logos-co/Overwatch/pull/93