### PR TITLE
feature(status-updater): Make notify_ready take a self reference instead of onwership.

### DIFF
--- a/overwatch/src/services/status/updater.rs
+++ b/overwatch/src/services/status/updater.rs
@@ -71,7 +71,13 @@ impl StatusUpdater<ServiceRunnerAPI> {
 
 impl StatusUpdater<ServiceAPI> {
     /// Shorthand for sending a [`ServiceStatus::Ready`] message.
-    pub fn notify_ready(self) {
+    ///
+    /// # Note
+    ///
+    /// Ideally, because this is used by the `Service`, it would take
+    /// ownership of the `StatusUpdater` so that it can only be used once.
+    /// However, this triggers partial move issues in a lot of scenarios.
+    pub fn notify_ready(&self) {
         self.send(ServiceStatus::Ready);
     }
 }

--- a/overwatch/src/services/status/updater.rs
+++ b/overwatch/src/services/status/updater.rs
@@ -76,6 +76,7 @@ impl StatusUpdater<ServiceAPI> {
     /// Shorthand for sending a [`ServiceStatus::Ready`] message.
     ///
     /// # Notes
+    ///
     /// - Calling this method multiple times has no additional effect.
     /// - Ideally, because this is used by the `Service`, it would take
     ///   ownership of the `StatusUpdater` so that it can only be used once.

--- a/overwatch/src/services/status/updater.rs
+++ b/overwatch/src/services/status/updater.rs
@@ -57,6 +57,8 @@ impl<API> StatusUpdater<API> {
     }
 }
 
+/// [`StatusUpdater`] implementation for the
+/// [`ServiceRunner`](crate::services::runner::ServiceRunner).
 impl StatusUpdater<ServiceRunnerAPI> {
     /// Shorthand for sending a [`ServiceStatus::Starting`] message.
     pub fn notify_starting(&self) {
@@ -69,14 +71,15 @@ impl StatusUpdater<ServiceRunnerAPI> {
     }
 }
 
+/// [`StatusUpdater`] implementation for the `Service`.
 impl StatusUpdater<ServiceAPI> {
     /// Shorthand for sending a [`ServiceStatus::Ready`] message.
     ///
-    /// # Note
-    ///
-    /// Ideally, because this is used by the `Service`, it would take
-    /// ownership of the `StatusUpdater` so that it can only be used once.
-    /// However, this triggers partial move issues in a lot of scenarios.
+    /// # Notes
+    /// - Calling this method multiple times has no additional effect.
+    /// - Ideally, because this is used by the `Service`, it would take
+    ///   ownership of the `StatusUpdater` so that it can only be used once.
+    ///   However, this triggers partial move issues in a lot of scenarios.
     pub fn notify_ready(&self) {
         self.send(ServiceStatus::Ready);
     }


### PR DESCRIPTION
In order to avoid triggering partial moves.