### PR TITLE
chore: replace dbg macro with debug macro

### DIFF
--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -6,7 +6,7 @@ use tokio::{
 };
 #[cfg(feature = "instrumentation")]
 use tracing::instrument;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::{
     overwatch::{
@@ -142,11 +142,11 @@ where
         ))
         .await
         .map_err(|e| {
-            dbg!(e);
+            debug!("{e:?}");
             ServiceError::Start
         })?;
         receiver.await.map_err(|e| {
-            dbg!(e);
+            debug!("{e:?}");
             ServiceError::Start
         })?;
         Ok(())
@@ -174,7 +174,7 @@ where
                 OverwatchLifeCycleCommand::StartServiceSequence(service_ids),
             ))
             .await
-            .map_err(|e| dbg!(e));
+            .map_err(|e| debug!("{e:?}"));
     }
 
     /// Send a start signal to the
@@ -191,7 +191,7 @@ where
                 OverwatchLifeCycleCommand::StartAllServices,
             ))
             .await
-            .map_err(|e| dbg!(e));
+            .map_err(|e| debug!("{e:?}"));
     }
 
     /// Send a stop signal to the specified service.
@@ -215,11 +215,11 @@ where
         ))
         .await
         .map_err(|e| {
-            dbg!(e);
+            debug!("{e:?}");
             ServiceError::Stop
         })?;
         receiver.await.map_err(|e| {
-            dbg!(e);
+            debug!("{e:?}");
             ServiceError::Stop
         })?;
         Ok(())
@@ -247,7 +247,7 @@ where
                 OverwatchLifeCycleCommand::StopServiceSequence(service_ids),
             ))
             .await
-            .map_err(|e| dbg!(e));
+            .map_err(|e| debug!("{e:?}"));
     }
 
     pub async fn stop_all_services(&self) {
@@ -257,7 +257,7 @@ where
                 OverwatchLifeCycleCommand::StopAllServices,
             ))
             .await
-            .map_err(|e| dbg!(e));
+            .map_err(|e| debug!("{e:?}"));
     }
 
     /// Send a shutdown signal to the
@@ -279,7 +279,7 @@ where
                 OverwatchLifeCycleCommand::Shutdown,
             ))
             .await
-            .map_err(|e| dbg!(e));
+            .map_err(|e| debug!("{e:?}"));
     }
 
     /// Send an overwatch command to the

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, future::Future};
 
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::{
     overwatch::handle::OverwatchHandle,
@@ -121,9 +121,8 @@ where
                     // TODO: Sending a different signal could be handy to differentiate whether
                     //  the service was already started or not.
                     if let Err(error) = finished_signal_sender.send(()) {
-                        dbg!(
-                            "Error while sending the LifecycleMessage::Start signal: {}.",
-                            error
+                        debug!(
+                            "Error while sending the LifecycleMessage::Start signal: {error:?}.",
                         );
                     }
                 }
@@ -143,7 +142,7 @@ where
                     // TODO: Sending a different signal could be handy to differentiate whether
                     //  the service was already stopped or not.
                     if let Err(error) = finished_signal_sender.send(()) {
-                        dbg!("Error while sending the LifecycleMessage::Stop finished signal: {}. Likely due to the receiver being already dropped in the Service::run task.", error);
+                        debug!("Error while sending the LifecycleMessage::Stop finished signal: {error:?}. Likely due to the receiver being already dropped in the Service::run task.");
                     }
                 }
             }


### PR DESCRIPTION
Probably an oversight, using `dbg!` pollutes our logs since they cannot be filtered out. I replaced them with `tracing::debug`, which results in cleaner output, especially in our CI.