### PR TITLE
chore: update Rust toolchain to 1.96

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746  # Version 1.0.6
         with:
-          toolchain: nightly-2026-02-28
+          toolchain: nightly-2026-04-11
           profile: minimal
           components: rustfmt
           override: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v1.0
     hooks:
       - id: fmt
-        entry: cargo +nightly-2026-02-28 fmt
+        entry: cargo +nightly-2026-04-11 fmt
       - id: clippy
   - repo: https://github.com/EmbarkStudios/cargo-deny
     rev: 0.18.0

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.95.0-slim-bullseye
+FROM rust:1.96.0-slim-bullseye
 
 LABEL maintainer="augustinas@status.im"
 LABEL source="https://github.com/logos-co/Overwatch"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,6 +5,6 @@
 # Also, update the version of the nightly toolchain to the latest nightly of the new version specified in the following places:
 # * .github/workflows/code-check.yml (fmt job)
 # * .pre-commit-config.yml (fmt hook)
-channel = "1.95.0"
+channel = "1.96.0"
 # Even if clippy should be included in the default profile, in some cases it is not installed. So we force it with an explicit declaration.
 components = ["clippy"]

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@
     overlays = [
       (import (fetchGit {
         url = "https://github.com/oxalica/rust-overlay.git";
-        rev = "8087ff1f47fff983a1fba70fa88b759f2fd8ae97";
+        rev = "40b0a3a193e0840c76174b4a322874c8f6dd0a63";
       }))
     ];
    }
@@ -19,7 +19,7 @@ pkgs.mkShell {
     pkg-config
     # Updating the version here requires also updating the `rev` version in the `overlays` section above
     # with a commit that contains the new version in its manifest
-    rust-bin.stable."1.95.0".default
+    rust-bin.stable."1.96.0".default
     go_1_19
   ];
 }


### PR DESCRIPTION
Fixes https://github.com/logos-co/Overwatch/issues/134.