### PR TITLE
feat: add opt-in tokio task naming

### DIFF
--- a/.cargo-deny.toml
+++ b/.cargo-deny.toml
@@ -19,7 +19,7 @@ unused-allowed-license = "deny"
 
 [[licenses.clarify]]
 expression    = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+license-files = [{ hash = 0xbd0eed23, path = "LICENSE" }]
 name          = "ring"
 
 [sources]

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -140,11 +140,18 @@ jobs:
         with:
           key: ${{ github.ref }}->${{ github.workflow }}->${{ github.job }}->${{ matrix.os }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cargo test
+      - name: Cargo test all targets and all features
         uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
         with:
           command: test
           args: --locked --all-targets --all-features
+      - name: Cargo test tokio-task-names with tokio_unstable
+        env:
+          RUSTFLAGS: --cfg tokio_unstable
+        uses: actions-rs/cargo@9e120dd99b0fbad1c065f686657e914e76bd7b72  # Version 1.0.1
+        with:
+          command: test
+          args: --locked -p overwatch -p overwatch-derive --features overwatch/tokio-task-names --lib --tests
       - name: Update Cargo cache
         if: success() || failure()
         uses: ./.github/actions/update-cargo-cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "bytes",
  "pin-project-lite",
  "tokio-macros",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/ping_pong/Cargo.toml
+++ b/examples/ping_pong/Cargo.toml
@@ -11,11 +11,11 @@ version     = { workspace = true }
 [dependencies]
 async-trait  = "0.1.83"
 const_format = "0.2.34"
-overwatch    = { workspace = true, features = ["derive"] }
-serde        = { version = "1.0.216", features = ["derive"] }
+overwatch    = { features = ["derive"], workspace = true }
+serde        = { features = ["derive"], version = "1.0.216" }
 serde_json   = "1.0.134"
 thiserror    = "2.0.8"
-tokio        = { version = "1.42.0", features = ["macros"] }
+tokio        = { features = ["macros"], version = "1.42.0" }
 tracing      = "0.1.41"
 
 [lints]

--- a/overwatch-derive/Cargo.toml
+++ b/overwatch-derive/Cargo.toml
@@ -24,12 +24,12 @@ convert_case = "0.8"
 manyhow      = "0.11"
 proc-macro2  = "1.0"
 quote        = "1.0"
-syn          = { version = "2.0", features = ["full"] }
-tracing      = { version = "0.1", optional = true }
+syn          = { features = ["full"], version = "2.0" }
+tracing      = { optional = true, version = "0.1" }
 
 [dev-dependencies]
 async-trait = "0.1"
-overwatch   = { workspace = true, features = ["derive"] }
+overwatch   = { features = ["derive"], workspace = true }
 tracing     = "0.1"
 
 [lints]

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -443,14 +443,6 @@ fn generate_new_impl(
                     let runner =
                         ::overwatch::OpaqueServiceRunner::<#service_type, Self::RuntimeServiceId>::new(
                             #settings_field_identifier, overwatch_handle.clone(), <#service_type as ::overwatch::services::ServiceData>::SERVICE_RELAY_BUFFER_SIZE
-                    )
-                    .with_task_names(
-                        <Self::RuntimeServiceId as ::overwatch::services::ServiceTaskNames>::service_task_name(
-                            &<Self::RuntimeServiceId as ::overwatch::services::AsServiceId<#service_type>>::SERVICE_ID,
-                        ),
-                        <Self::RuntimeServiceId as ::overwatch::services::ServiceTaskNames>::state_task_name(
-                            &<Self::RuntimeServiceId as ::overwatch::services::AsServiceId<#service_type>>::SERVICE_ID,
-                        ),
                     );
                     let service_runner_handle = runner.run::<#service_type>();
                     service_runner_handle

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -443,6 +443,14 @@ fn generate_new_impl(
                     let runner =
                         ::overwatch::OpaqueServiceRunner::<#service_type, Self::RuntimeServiceId>::new(
                             #settings_field_identifier, overwatch_handle.clone(), <#service_type as ::overwatch::services::ServiceData>::SERVICE_RELAY_BUFFER_SIZE
+                    )
+                    .with_task_names(
+                        <Self::RuntimeServiceId as ::overwatch::services::ServiceTaskNames>::service_task_name(
+                            &<Self::RuntimeServiceId as ::overwatch::services::AsServiceId<#service_type>>::SERVICE_ID,
+                        ),
+                        <Self::RuntimeServiceId as ::overwatch::services::ServiceTaskNames>::state_task_name(
+                            &<Self::RuntimeServiceId as ::overwatch::services::AsServiceId<#service_type>>::SERVICE_ID,
+                        ),
                     );
                     let service_runner_handle = runner.run::<#service_type>();
                     service_runner_handle
@@ -1030,6 +1038,7 @@ fn generate_runtime_service_types(fields: &Punctuated<Field, Comma>) -> proc_mac
     let runtime_service_id = generate_runtime_service_id(fields);
     let service_id_trait_impls = generate_service_id_trait_impls(fields);
     let as_service_id_impl = generate_as_service_id_impl(fields);
+    let service_task_names_impl = generate_service_task_names_impl(fields);
 
     quote! {
         #runtime_service_id
@@ -1037,6 +1046,50 @@ fn generate_runtime_service_types(fields: &Punctuated<Field, Comma>) -> proc_mac
         #service_id_trait_impls
 
         #as_service_id_impl
+
+        #service_task_names_impl
+    }
+}
+
+fn generate_service_task_names_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStream {
+    let service_task_names = fields.iter().map(|field| {
+        let service_name = field.ident.as_ref().expect("Expected struct named fields.");
+        let service_variant = format_ident!(
+            "{}",
+            utils::field_name_to_type_name(&service_name.to_string())
+        );
+
+        quote! {
+            Self::#service_variant => concat!("overwatch-service/", stringify!(#service_name)),
+        }
+    });
+    let state_task_names = fields.iter().map(|field| {
+        let service_name = field.ident.as_ref().expect("Expected struct named fields.");
+        let service_variant = format_ident!(
+            "{}",
+            utils::field_name_to_type_name(&service_name.to_string())
+        );
+
+        quote! {
+            Self::#service_variant => concat!("overwatch-state/", stringify!(#service_name)),
+        }
+    });
+    let runtime_service_id_type_name = get_runtime_service_id_type_name();
+
+    quote! {
+        impl ::overwatch::services::ServiceTaskNames for #runtime_service_id_type_name {
+            fn service_task_name(&self) -> &'static str {
+                match self {
+                    #(#service_task_names)*
+                }
+            }
+
+            fn state_task_name(&self) -> &'static str {
+                match self {
+                    #(#state_task_names)*
+                }
+            }
+        }
     }
 }
 

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -1044,24 +1044,28 @@ fn generate_runtime_service_types(fields: &Punctuated<Field, Comma>) -> proc_mac
 }
 
 fn generate_service_task_names_impl(fields: &Punctuated<Field, Comma>) -> proc_macro2::TokenStream {
-    let service_task_names = fields.iter().map(|field| {
-        let service_name = field.ident.as_ref().expect("Expected struct named fields.");
-        let service_variant = format_ident!(
-            "{}",
-            utils::field_name_to_type_name(&service_name.to_string())
-        );
+    let service_names = fields
+        .iter()
+        .map(|field| {
+            let service_name = field
+                .ident
+                .as_ref()
+                .expect("Expected struct named fields.")
+                .clone();
+            let service_variant = format_ident!(
+                "{}",
+                utils::field_name_to_type_name(&service_name.to_string())
+            );
 
+            (service_name, service_variant)
+        })
+        .collect::<Vec<_>>();
+    let service_task_names = service_names.iter().map(|(service_name, service_variant)| {
         quote! {
             Self::#service_variant => concat!("overwatch-service/", stringify!(#service_name)),
         }
     });
-    let state_task_names = fields.iter().map(|field| {
-        let service_name = field.ident.as_ref().expect("Expected struct named fields.");
-        let service_variant = format_ident!(
-            "{}",
-            utils::field_name_to_type_name(&service_name.to_string())
-        );
-
+    let state_task_names = service_names.iter().map(|(service_name, service_variant)| {
         quote! {
             Self::#service_variant => concat!("overwatch-state/", stringify!(#service_name)),
         }

--- a/overwatch/Cargo.toml
+++ b/overwatch/Cargo.toml
@@ -14,23 +14,24 @@ version     = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default         = ["derive"]
-derive          = ["dep:overwatch-derive"]
-instrumentation = []
+default          = ["derive"]
+derive           = ["dep:overwatch-derive"]
+instrumentation  = []
+tokio-task-names = ["tokio/rt", "tokio/tracing"]
 
 [dependencies]
 async-trait      = "0.1"
 futures          = "0.3"
-overwatch-derive = { workspace = true, optional = true }
+overwatch-derive = { optional = true, workspace = true }
 thiserror        = "2.0"
-tokio            = { version = "1.32", features = ["macros", "rt-multi-thread", "sync", "time"] }
-tokio-stream     = { version = "0.1", features = ["sync"] }
+tokio            = { features = ["macros", "rt-multi-thread", "sync", "time"], version = "1.32" }
+tokio-stream     = { features = ["sync"], version = "0.1" }
 tokio-util       = "0.7"
 tracing          = "0.1"
 
 [dev-dependencies]
-overwatch = { path = ".", features = ["derive"] }
-tokio     = { version = "1.17", features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"] }
+overwatch = { features = ["derive"], path = "." }
+tokio     = { features = ["io-std", "io-util", "macros", "rt-multi-thread", "sync", "time"], version = "1.17" }
 
 [lints]
 workspace = true

--- a/overwatch/README.md
+++ b/overwatch/README.md
@@ -95,6 +95,19 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 ```
 
+### Tokio Task Names
+
+Enable the `tokio-task-names` feature to name Overwatch-managed service and
+state-handler tasks for Tokio tracing and profiling tools. Tokio requires its
+unstable configuration for task names, so consumers must also build with
+`RUSTFLAGS="--cfg tokio_unstable"`. Enabling the Cargo feature alone keeps the
+existing unnamed spawn behavior.
+
+```toml
+[dependencies]
+overwatch = { version = "1", features = ["tokio-task-names"] }
+```
+
 ### Creating a Service
 
 Every service implements two traits:

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -59,6 +59,14 @@ pub trait AsServiceId<T> {
     const SERVICE_ID: Self;
 }
 
+/// Provides static names for tasks managed by a service runner.
+pub trait ServiceTaskNames {
+    /// The name of the task running the service.
+    fn service_task_name(&self) -> &'static str;
+    /// The name of the task running the service state handler.
+    fn state_task_name(&self) -> &'static str;
+}
+
 /// Main trait for Services initialization and main loop hook.
 ///
 /// # Note

--- a/overwatch/src/services/mod.rs
+++ b/overwatch/src/services/mod.rs
@@ -59,10 +59,11 @@ pub trait AsServiceId<T> {
     const SERVICE_ID: Self;
 }
 
-/// Provides static names for tasks managed by a service runner.
+/// Provides static Tokio task names for services in a generated runtime.
 pub trait ServiceTaskNames {
     /// The name of the task running the service.
     fn service_task_name(&self) -> &'static str;
+
     /// The name of the task running the service state handler.
     fn state_task_name(&self) -> &'static str;
 }

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -17,6 +17,12 @@ use crate::{
     utils::finished_signal,
 };
 
+#[derive(Clone, Copy)]
+struct TaskNames {
+    service: &'static str,
+    state: &'static str,
+}
+
 #[expect(
     unexpected_cfgs,
     reason = "tokio_unstable is supplied externally through RUSTFLAGS"
@@ -60,8 +66,6 @@ enum ServiceLifecyclePhase {
 pub struct ServiceRunner<Message, Settings, State, StateOperator, RuntimeServiceId> {
     service_resources: ServiceResources<Message, Settings, State, StateOperator, RuntimeServiceId>,
     service_lifecycle_phase: ServiceLifecyclePhase,
-    service_task_name: Option<&'static str>,
-    state_task_name: Option<&'static str>,
 }
 
 impl<Message, Settings, State, StateOp, RuntimeServiceId>
@@ -88,23 +92,14 @@ where
         Self {
             service_resources,
             service_lifecycle_phase: ServiceLifecyclePhase::Stopped,
-            service_task_name: None,
-            state_task_name: None,
         }
-    }
-
-    #[must_use]
-    pub const fn with_task_names(
-        mut self,
-        service_task_name: &'static str,
-        state_task_name: &'static str,
-    ) -> Self {
-        self.service_task_name = Some(service_task_name);
-        self.state_task_name = Some(state_task_name);
-        self
     }
 }
 
+#[expect(
+    unexpected_cfgs,
+    reason = "tokio_unstable is supplied externally through RUSTFLAGS"
+)]
 impl<Message, Settings, State, StateOp, RuntimeServiceId>
     ServiceRunner<Message, Settings, State, StateOp, RuntimeServiceId>
 where
@@ -122,7 +117,37 @@ where
     ///
     /// A [`ServiceRunnerHandle`] that contains the [`ServiceHandle`] and the
     /// [`JoinHandle`] of the [`ServiceRunner`] task.
+    #[cfg(all(feature = "tokio-task-names", tokio_unstable))]
     pub fn run<Service>(self) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
+    where
+        Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
+            + 'static,
+        StateOp: Clone,
+        RuntimeServiceId: crate::services::AsServiceId<Service> + crate::services::ServiceTaskNames,
+    {
+        let service_id = <RuntimeServiceId as crate::services::AsServiceId<Service>>::SERVICE_ID;
+        let task_names = TaskNames {
+            service: service_id.service_task_name(),
+            state: service_id.state_task_name(),
+        };
+
+        self.spawn_runner::<Service>(Some(task_names))
+    }
+
+    #[cfg(not(all(feature = "tokio-task-names", tokio_unstable)))]
+    pub fn run<Service>(self) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
+    where
+        Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
+            + 'static,
+        StateOp: Clone,
+    {
+        self.spawn_runner::<Service>(None)
+    }
+
+    fn spawn_runner<Service>(
+        self,
+        task_names: Option<TaskNames>,
+    ) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -130,12 +155,12 @@ where
     {
         let service_handle = ServiceHandle::from(&self.service_resources);
         let runtime = self.service_resources.overwatch_handle().runtime().clone();
-        let runner_join_handle = runtime.spawn(self.run_::<Service>());
+        let runner_join_handle = runtime.spawn(self.run_::<Service>(task_names));
 
         ServiceRunnerHandle::new(service_handle, runner_join_handle)
     }
 
-    async fn run_<Service>(self)
+    async fn run_<Service>(self, task_names: Option<TaskNames>)
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -144,8 +169,6 @@ where
         let Self {
             mut service_resources,
             mut service_lifecycle_phase,
-            service_task_name,
-            state_task_name,
         } = self;
 
         // Handles to hold the Service and StateHandle tasks
@@ -162,8 +185,7 @@ where
                             &mut service_resources,
                             &mut service_task_handle,
                             &mut state_handle_task_handle,
-                            service_task_name,
-                            state_task_name,
+                            task_names,
                         );
                         service_lifecycle_phase = ServiceLifecyclePhase::Started;
                     }
@@ -213,8 +235,7 @@ where
         >,
         service_task_handle: &mut Option<JoinHandle<()>>,
         state_handle_task_handle: &mut Option<JoinHandle<()>>,
-        service_task_name: Option<&'static str>,
-        state_task_name: Option<&'static str>,
+        task_names: Option<TaskNames>,
     ) where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -251,8 +272,7 @@ where
             service_resources,
             service_task_handle,
             state_handle_task_handle,
-            service_task_name,
-            state_task_name,
+            task_names,
         );
     }
 
@@ -261,8 +281,7 @@ where
         service_resources: &ServiceResources<Message, Settings, State, StateOp, RuntimeServiceId>,
         service_task_handle: &mut Option<JoinHandle<()>>,
         state_handle_task_handle: &mut Option<JoinHandle<()>>,
-        service_task_name: Option<&'static str>,
-        state_task_name: Option<&'static str>,
+        task_names: Option<TaskNames>,
     ) where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -294,9 +313,17 @@ where
                 }
             }
         };
-        *service_task_handle = Some(spawn_task(&runtime, service_task_name, service_task));
+        *service_task_handle = Some(spawn_task(
+            &runtime,
+            task_names.map(|task_names| task_names.service),
+            service_task,
+        ));
         let state_handle_task = service_resources.state_handle().clone().run();
-        *state_handle_task_handle = Some(spawn_task(&runtime, state_task_name, state_handle_task));
+        *state_handle_task_handle = Some(spawn_task(
+            &runtime,
+            task_names.map(|task_names| task_names.state),
+            state_handle_task,
+        ));
     }
 
     /// Handles a [`LifecycleMessage::Stop`] event, ensuring proper shutdown and

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -31,10 +31,14 @@ where
 {
     #[cfg(all(feature = "tokio-task-names", tokio_unstable))]
     {
-        tokio::task::Builder::new()
-            .name(name.expect("a name is required when tokio-task-names is enabled"))
-            .spawn_on(future, runtime)
-            .expect("failed to spawn named Overwatch task")
+        if let Some(name) = name {
+            return tokio::task::Builder::new()
+                .name(name)
+                .spawn_on(future, runtime)
+                .expect("failed to spawn named Overwatch task");
+        }
+
+        runtime.spawn(future)
     }
 
     #[cfg(not(all(feature = "tokio-task-names", tokio_unstable)))]

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -17,6 +17,33 @@ use crate::{
     utils::finished_signal,
 };
 
+#[expect(
+    unexpected_cfgs,
+    reason = "tokio_unstable is supplied externally through RUSTFLAGS"
+)]
+fn spawn_task<T>(
+    runtime: &tokio::runtime::Handle,
+    name: Option<&'static str>,
+    future: impl Future<Output = T> + Send + 'static,
+) -> JoinHandle<T>
+where
+    T: Send + 'static,
+{
+    #[cfg(all(feature = "tokio-task-names", tokio_unstable))]
+    {
+        tokio::task::Builder::new()
+            .name(name.expect("a name is required when tokio-task-names is enabled"))
+            .spawn_on(future, runtime)
+            .expect("failed to spawn named Overwatch task")
+    }
+
+    #[cfg(not(all(feature = "tokio-task-names", tokio_unstable)))]
+    {
+        let _ = name;
+        runtime.spawn(future)
+    }
+}
+
 #[derive(PartialEq, Eq)]
 enum ServiceLifecyclePhase {
     Started,
@@ -29,6 +56,8 @@ enum ServiceLifecyclePhase {
 pub struct ServiceRunner<Message, Settings, State, StateOperator, RuntimeServiceId> {
     service_resources: ServiceResources<Message, Settings, State, StateOperator, RuntimeServiceId>,
     service_lifecycle_phase: ServiceLifecyclePhase,
+    service_task_name: Option<&'static str>,
+    state_task_name: Option<&'static str>,
 }
 
 impl<Message, Settings, State, StateOp, RuntimeServiceId>
@@ -55,7 +84,20 @@ where
         Self {
             service_resources,
             service_lifecycle_phase: ServiceLifecyclePhase::Stopped,
+            service_task_name: None,
+            state_task_name: None,
         }
+    }
+
+    #[must_use]
+    pub const fn with_task_names(
+        mut self,
+        service_task_name: &'static str,
+        state_task_name: &'static str,
+    ) -> Self {
+        self.service_task_name = Some(service_task_name);
+        self.state_task_name = Some(state_task_name);
+        self
     }
 }
 
@@ -98,6 +140,8 @@ where
         let Self {
             mut service_resources,
             mut service_lifecycle_phase,
+            service_task_name,
+            state_task_name,
         } = self;
 
         // Handles to hold the Service and StateHandle tasks
@@ -114,6 +158,8 @@ where
                             &mut service_resources,
                             &mut service_task_handle,
                             &mut state_handle_task_handle,
+                            service_task_name,
+                            state_task_name,
                         );
                         service_lifecycle_phase = ServiceLifecyclePhase::Started;
                     }
@@ -163,6 +209,8 @@ where
         >,
         service_task_handle: &mut Option<JoinHandle<()>>,
         state_handle_task_handle: &mut Option<JoinHandle<()>>,
+        service_task_name: Option<&'static str>,
+        state_task_name: Option<&'static str>,
     ) where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -199,6 +247,8 @@ where
             service_resources,
             service_task_handle,
             state_handle_task_handle,
+            service_task_name,
+            state_task_name,
         );
     }
 
@@ -207,6 +257,8 @@ where
         service_resources: &ServiceResources<Message, Settings, State, StateOp, RuntimeServiceId>,
         service_task_handle: &mut Option<JoinHandle<()>>,
         state_handle_task_handle: &mut Option<JoinHandle<()>>,
+        service_task_name: Option<&'static str>,
+        state_task_name: Option<&'static str>,
     ) where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -238,9 +290,9 @@ where
                 }
             }
         };
-        *service_task_handle = Some(runtime.spawn(service_task));
+        *service_task_handle = Some(spawn_task(&runtime, service_task_name, service_task));
         let state_handle_task = service_resources.state_handle().clone().run();
-        *state_handle_task_handle = Some(runtime.spawn(state_handle_task));
+        *state_handle_task_handle = Some(spawn_task(&runtime, state_task_name, state_handle_task));
     }
 
     /// Handles a [`LifecycleMessage::Stop`] event, ensuring proper shutdown and

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -134,6 +134,13 @@ where
         self.spawn_runner::<Service>(Some(task_names))
     }
 
+    /// Spawn the `ServiceRunner` loop. This will listen for lifecycle messages
+    /// and act upon them.
+    ///
+    /// # Returns
+    ///
+    /// A [`ServiceRunnerHandle`] that contains the [`ServiceHandle`] and the
+    /// [`JoinHandle`] of the [`ServiceRunner`] task.
     #[cfg(not(all(feature = "tokio-task-names", tokio_unstable)))]
     pub fn run<Service>(self) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
     where

--- a/overwatch/tests/services.rs
+++ b/overwatch/tests/services.rs
@@ -164,6 +164,27 @@ fn generated_service_task_names_are_static_and_stable() {
     assert_eq!(service_id.state_task_name(), "overwatch-state/service_a");
 }
 
+#[cfg(feature = "tokio-task-names")]
+#[test]
+fn tokio_task_names_preserve_service_lifecycle() {
+    let overwatch = initialize();
+    let runtime = overwatch.runtime().handle();
+
+    runtime
+        .block_on(overwatch.handle().start_service::<ServiceA>())
+        .expect("Failed to start service A");
+
+    let mut status_watcher = runtime.block_on(overwatch.handle().status_watcher::<ServiceA>());
+    wait_for_status(runtime, &mut status_watcher, ServiceStatus::Ready);
+
+    runtime
+        .block_on(overwatch.handle().stop_service::<ServiceA>())
+        .expect("Failed to stop service A");
+    wait_for_status(runtime, &mut status_watcher, ServiceStatus::Stopped);
+
+    let _ = runtime.block_on(overwatch.handle().shutdown());
+}
+
 fn initialize() -> Overwatch<RuntimeServiceId> {
     let settings = AppServiceSettings {
         service_a: (),

--- a/overwatch/tests/services.rs
+++ b/overwatch/tests/services.rs
@@ -185,6 +185,39 @@ fn tokio_task_names_preserve_service_lifecycle() {
     let _ = runtime.block_on(overwatch.handle().shutdown());
 }
 
+#[cfg(feature = "tokio-task-names")]
+#[test]
+fn generated_service_task_names_are_static_stable_and_unique() {
+    let service_a = <RuntimeServiceId as AsServiceId<ServiceA>>::SERVICE_ID;
+    let service_b = <RuntimeServiceId as AsServiceId<ServiceB>>::SERVICE_ID;
+    let service_c = <RuntimeServiceId as AsServiceId<ServiceC>>::SERVICE_ID;
+
+    assert_eq!(service_a.service_task_name(), "overwatch-service/service_a");
+    assert_eq!(service_a.state_task_name(), "overwatch-state/service_a");
+
+    assert_eq!(service_b.service_task_name(), "overwatch-service/service_b");
+    assert_eq!(service_b.state_task_name(), "overwatch-state/service_b");
+
+    assert_eq!(service_c.service_task_name(), "overwatch-service/service_c");
+    assert_eq!(service_c.state_task_name(), "overwatch-state/service_c");
+
+    let names = [
+        service_a.service_task_name(),
+        service_a.state_task_name(),
+        service_b.service_task_name(),
+        service_b.state_task_name(),
+        service_c.service_task_name(),
+        service_c.state_task_name(),
+    ];
+
+    for (index, name) in names.iter().enumerate() {
+        assert!(
+            names[index + 1..].iter().all(|other| other != name),
+            "duplicate generated task name: {name}"
+        );
+    }
+}
+
 fn initialize() -> Overwatch<RuntimeServiceId> {
     let settings = AppServiceSettings {
         service_a: (),

--- a/overwatch/tests/services.rs
+++ b/overwatch/tests/services.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+#[cfg(feature = "tokio-task-names")]
+use overwatch::services::ServiceTaskNames as _;
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle,
     overwatch::{Overwatch, OverwatchRunner},
@@ -148,6 +150,18 @@ struct App {
     service_a: ServiceA,
     service_b: ServiceB,
     service_c: ServiceC,
+}
+
+#[cfg(feature = "tokio-task-names")]
+#[test]
+fn generated_service_task_names_are_static_and_stable() {
+    let service_id = <RuntimeServiceId as AsServiceId<ServiceA>>::SERVICE_ID;
+
+    assert_eq!(
+        service_id.service_task_name(),
+        "overwatch-service/service_a"
+    );
+    assert_eq!(service_id.state_task_name(), "overwatch-state/service_a");
 }
 
 fn initialize() -> Overwatch<RuntimeServiceId> {


### PR DESCRIPTION
Implemented opt-in Tokio task naming for Overwatch-managed service and state-handler tasks.

- Added tokio-task-names feature with Tokio rt and tracing support.
- Added stable static names:
    - overwatch-service/<service-id>
    - overwatch-state/<service-id>
- Centralized task spawning through a feature-gated helper.
- Preserved existing spawn and lifecycle behavior when disabled.
- Added static naming coverage.
- Added fallback behavior so `cargo clippy --all --all-targets --all-features` works without `tokio_unstable`.

System-level testing when integrated with https://github.com/logos-blockchain/logos-blockchain/pull/3129 - note the named `overwatch-service` and `overwatch-state` tokio tasks:
```
connection: http://127.0.0.1:20000/ (RECONNECTING IN 13s) PAUSED
views: t = tasks, r = resources
controls: select column (sort) = ←→ or h, l, scroll = ↑↓ or k, j, view details = ↵, invert sort (highest/lowest) = i, scroll to top = gg, scroll to bottom = G, toggle pause = space, quit = q
╭Warnings───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│⚠ 2 tasks have woken themselves over 50% of the time                                                                                                                                                                                                               │
│⚠ 7 tasks are 1024 bytes or larger                                                                                                                                                                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭Tasks (21) ▶ Running (0) ⏸ Idle (21)───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│   Warn  ID  State  Name                          Total▿ Busy   Sched  Idle   Polls Kind   Location                                                                                     Fields                                                                     │
│         106 ⏸      overwatch-service/tracing      1m20s   11µs    0ns  1m20s 1     task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=528 target=tokio::task                                          │
│         107 ⏸      overwatch-state/tracing        1m20s    4µs    0ns  1m20s 1     task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=176 target=tokio::task                                          │
│         108 ⏸      overwatch-service/cryptarchia  1m20s   81ms   11ms  1m19s 1305  task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=528 target=tokio::task                                          │
│>> ⚠ 1   109 ⏸      overwatch-state/cryptarchia    1m20s    7ms  549µs  1m19s 9     task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=7544 target=tokio::task                                         │
│         113 ⏸                                     1m19s    1ms    4ms  1m19s 114   task   <cargo>/quinn-0.11.11/src/endpoint.rs:153:17                                                 size.bytes=16 target=tokio::task                                           │
│   ⚠ 1   114 ⏸                                     1m19s    6ms    4ms  1m19s 73    task   services/network/src/backends/libp2p/mod.rs:61:36                                            size.bytes=8432 target=tokio::task                                         │
│         115 ⏸      overwatch-service/network      1m19s  305µs  681µs  1m19s 14    task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=528 target=tokio::task                                          │
│         116 ⏸      overwatch-state/network        1m19s    5µs    0ns  1m19s 1     task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=176 target=tokio::task                                          │
│         118 ⏸      overwatch-service/storage      1m19s  945µs  176µs  1m19s 24    task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=528 target=tokio::task                                          │
│         119 ⏸      overwatch-state/storage        1m19s    4µs    0ns  1m19s 1     task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=176 target=tokio::task                                          │
│   ⚠ 1   120 ⏸                                     1m19s  158ms   53ms  1m19s 2125  task   <cargo>/axum-0.7.9/src/serve.rs:253:17                                                       size.bytes=1808 target=tokio::task                                         │
│         129 ⏸      overwatch-service/blend_core   1m13s  480ms     7s  1m06s 1316  task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=528 target=tokio::task                                          │
│   ⚠ 1   130 ⏸      overwatch-state/blend_core     1m13s   71ms   74ms  1m13s 97    task   /home/pluto/Code/logos/logos-overwatch/overwatch/src/services/runner/service_runner.rs:37:18 size.bytes=1336 target=tokio::task                                         │
│   ⚠ 1   136 ⏸                                     1m13s    7ms   12ms  1m13s 419   task   <cargo>/quinn-0.11.11/src/endpoint.rs:153:17                                                 size.bytes=16 target=tokio::task                                           │
│   ⚠ 2   138 ⏸                                     1m13s   23ms   13ms  1m13s 185   task   services/blend/src/core/backends/libp2p/mod.rs:85:14                                         size.bytes=5392 target=tokio::task                                         │
│         141 ⏸                                     1m13s    8ms    3ms  1m13s 120   task   <cargo>/quinn-0.11.11/src/connection.rs:66:17                                                size.bytes=16 target=tokio::task                                           │
│         143 ⏸                                     1m13s    3ms    1ms  1m13s 23    task   <cargo>/libp2p-swarm-0.46.0/src/connection/pool.rs:542:23                                    size.bytes=16 target=tokio::task                                           │
│   ⚠ 1   148 ⏸                                     1m13s  396µs    6ms  1m13s 78    task   services/chain/chain-leader/src/lib.rs:725:17                                                size.bytes=2336 target=tokio::task                                         │
│         200 ⏸                                     1m06s   31ms    8ms  1m06s 280   task   <cargo>/quinn-0.11.11/src/connection.rs:66:17                                                size.bytes=16 target=tokio::task                                           │
│         201 ⏸                                     1m06s   10ms    3ms  1m06s 118   task   <cargo>/libp2p-swarm-0.46.0/src/connection/pool.rs:542:23                                    size.bytes=16 target=tokio::task                                           │
│   ⚠ 1   233 ⏸                                     1m01s   42ms   14ms  1m01s 571   task   <cargo>/axum-0.7.9/src/serve.rs:253:17                                                       size.bytes=1808 target=tokio::task                                         │

```
