### PR TITLE
feat: provide runtime handle to state operators

### DIFF
--- a/examples/ping_pong/README.md
+++ b/examples/ping_pong/README.md
@@ -131,13 +131,22 @@ impl ServiceState for PingState {
 
 ```rust
 #[async_trait]
-impl StateOperator for StateSaveOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for StateSaveOperator {
     type State = PingState;
     
     fn try_load(settings: &Settings) -> Result<Option<Self::State>, Self::LoadError> {
         // Load from JSON file
         let state_string = std::fs::read_to_string(&settings.state_save_path)?;
         serde_json::from_str(&state_string).map_err(...)
+    }
+
+    fn from_settings(
+        settings: &Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
+        Self {
+            save_path: settings.state_save_path.clone(),
+        }
     }
     
     async fn run(&mut self, state: Self::State) {

--- a/examples/ping_pong/src/operators.rs
+++ b/examples/ping_pong/src/operators.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use overwatch::services::state::{ServiceState, StateOperator};
+use overwatch::{
+    overwatch::OverwatchHandle,
+    services::state::{ServiceState, StateOperator},
+};
 
 use crate::states::PingState;
 
@@ -10,7 +13,7 @@ pub struct StateSaveOperator {
 }
 
 #[async_trait::async_trait]
-impl StateOperator for StateSaveOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for StateSaveOperator {
     type State = PingState;
     type LoadError = std::io::Error;
 
@@ -22,7 +25,10 @@ impl StateOperator for StateSaveOperator {
             .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
     }
 
-    fn from_settings(settings: &<Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(
+        settings: &<Self::State as ServiceState>::Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
         Self {
             save_path: settings.state_save_path.clone(),
         }

--- a/overwatch-derive/src/lib.rs
+++ b/overwatch-derive/src/lib.rs
@@ -75,6 +75,7 @@ pub fn derive_services(_attr: TokenStream, item: TokenStream) -> TokenStream {
         panic!("`derive_services` macro only supports structs with named fields");
     };
     let fields = named_fields.named;
+    let runtime_service_id_type_name = get_runtime_service_id_type_name();
 
     let modified_fields = fields.iter().map(|field| {
         let field_name = &field.ident;
@@ -82,7 +83,7 @@ pub fn derive_services(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let field_attrs = &field.attrs; // Preserve attributes (including feature flags)
 
         let new_field_type = quote! {
-            ::overwatch::OpaqueServiceRunnerHandle<#field_type>
+            ::overwatch::OpaqueServiceRunnerHandle<#field_type, #runtime_service_id_type_name>
         };
 
         quote! {

--- a/overwatch/README.md
+++ b/overwatch/README.md
@@ -205,12 +205,19 @@ State operators handle persistence:
 
 ```rust
 #[async_trait]
-impl StateOperator for MyOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for MyOperator {
     type State = MyState;
     type LoadError = std::io::Error;
     
     fn try_load(settings: &Settings) -> Result<Option<Self::State>, Self::LoadError> {
         // Load state from disk/database
+    }
+
+    fn from_settings(
+        settings: &Settings,
+        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
+        // Build the operator from settings and runtime services
     }
     
     async fn run(&mut self, state: Self::State) {

--- a/overwatch/src/lib.rs
+++ b/overwatch/src/lib.rs
@@ -15,17 +15,19 @@ pub type OpaqueServiceRunner<S, RuntimeServiceId> = services::runner::ServiceRun
     <S as ServiceData>::StateOperator,
     RuntimeServiceId,
 >;
-pub type OpaqueServiceHandle<S> = services::service_handle::ServiceHandle<
+pub type OpaqueServiceHandle<S, RuntimeServiceId> = services::service_handle::ServiceHandle<
     <S as ServiceData>::Message,
     <S as ServiceData>::Settings,
     <S as ServiceData>::State,
     <S as ServiceData>::StateOperator,
+    RuntimeServiceId,
 >;
-pub type OpaqueServiceRunnerHandle<S> = services::runner::ServiceRunnerHandle<
+pub type OpaqueServiceRunnerHandle<S, RuntimeServiceId> = services::runner::ServiceRunnerHandle<
     <S as ServiceData>::Message,
     <S as ServiceData>::Settings,
     <S as ServiceData>::State,
     <S as ServiceData>::StateOperator,
+    RuntimeServiceId,
 >;
 pub type OpaqueServiceResourcesHandle<S, RuntimeServiceId> =
     services::resources::ServiceResourcesHandle<

--- a/overwatch/src/overwatch/runner.rs
+++ b/overwatch/src/overwatch/runner.rs
@@ -288,10 +288,14 @@ async fn handle_service_lifecycle_command_operation<F>(
 ) where
     F: Future<Output = Result<(), Error>> + Send,
 {
-    if let Err(error) = operation.await {
-        error!(error=?error, "Error while running {operation_name} operation.");
-    }
-    if let Err(error) = sender.send(()) {
-        error!(error=?error, "Error while sending the finished signal for {operation_name} operation.");
+    match operation.await {
+        Ok(()) => {
+            if let Err(error) = sender.send(()) {
+                error!(error=?error, "Error while sending the finished signal for {operation_name} operation.");
+            }
+        }
+        Err(error) => {
+            error!(error=?error, "Error while running {operation_name} operation.");
+        }
     }
 }

--- a/overwatch/src/services/resources.rs
+++ b/overwatch/src/services/resources.rs
@@ -1,5 +1,13 @@
 use tracing::info;
 
+#[derive(Debug, thiserror::Error)]
+pub enum InitialStateError<StateError, OperatorError> {
+    #[error("Failed to load initial state from operator: {0}")]
+    Operator(OperatorError),
+    #[error("Failed to create initial state from settings: {0}")]
+    Settings(StateError),
+}
+
 use crate::{
     DynError,
     overwatch::handle::OverwatchHandle,
@@ -27,7 +35,7 @@ pub struct ServiceResources<Message, Settings, State, StateOperator, RuntimeServ
     // Settings
     settings_handle: SettingsHandle<Settings>,
     // State
-    state_handle: StateHandle<State, StateOperator>,
+    state_handle: StateHandle<State, StateOperator, RuntimeServiceId>,
     state_updater: StateUpdater<Option<State>>,
     operator_fuse_sender: fuse::Sender,
     // Lifecycle
@@ -46,7 +54,7 @@ where
     RuntimeServiceId: Clone,
     Settings: Clone,
     State: ServiceState<Settings = Settings> + Clone,
-    StateOperator: StateOperatorTrait<State = State>,
+    StateOperator: StateOperatorTrait<RuntimeServiceId, State = State>,
 {
     #[must_use]
     pub fn new(
@@ -57,12 +65,16 @@ where
         let lifecycle_handle = LifecycleHandle::new();
         let relay = Relay::new(relay_buffer_size);
         let status_handle = StatusHandle::new();
-        let state_operator = StateOperator::from_settings(&settings);
+        let state_operator = StateOperator::from_settings(&settings, overwatch_handle.clone());
         let settings_handle = SettingsHandle::new(settings);
 
         let (operator_fuse_sender, operator_fuse_receiver) = fuse::channel();
         let (state_handle, state_updater) =
-            StateHandle::<State, StateOperator>::new(state_operator, None, operator_fuse_receiver);
+            StateHandle::<State, StateOperator, RuntimeServiceId>::new(
+                state_operator,
+                None,
+                operator_fuse_receiver,
+            );
 
         let Relay {
             inbound_relay,
@@ -99,7 +111,7 @@ where
         &self.settings_handle
     }
 
-    pub const fn state_handle(&self) -> &StateHandle<State, StateOperator> {
+    pub const fn state_handle(&self) -> &StateHandle<State, StateOperator, RuntimeServiceId> {
         &self.state_handle
     }
 
@@ -160,20 +172,27 @@ where
     /// Retrieves the initial state for the service.
     ///
     /// First tries to load the state from the operator (a previously saved
-    /// state). If it fails, it defaults to the initial state created from
-    /// the settings.
+    /// state). If no state exists, it defaults to the initial state created
+    /// from the settings. Operator errors are returned to the caller.
     ///
     /// # Errors
     ///
-    /// If the State fails to load from Settings.
-    pub fn get_service_initial_state(&self) -> Result<State, State::Error> {
+    /// If the operator fails to load state or the state cannot be created from
+    /// settings.
+    pub fn get_service_initial_state(
+        &self,
+    ) -> Result<State, InitialStateError<State::Error, StateOperator::LoadError>> {
         let settings = self.settings_handle.notifier().get_updated_settings();
-        if let Ok(Some(loaded_state)) = StateOperator::try_load(&settings) {
-            info!("Loaded state from Operator");
-            Ok(loaded_state)
-        } else {
-            info!("Couldn't load state from Operator. Creating from settings.");
-            State::from_settings(&settings)
+        match StateOperator::try_load(&settings) {
+            Ok(Some(loaded_state)) => {
+                info!("Loaded state from Operator");
+                Ok(loaded_state)
+            }
+            Ok(None) => {
+                info!("No state found in Operator. Creating from settings.");
+                State::from_settings(&settings).map_err(InitialStateError::Settings)
+            }
+            Err(error) => Err(InitialStateError::Operator(error)),
         }
     }
 
@@ -213,7 +232,7 @@ pub struct ServiceResourcesHandle<Message, Settings, State, RuntimeServiceId> {
 
 impl<Message, Settings, State, Operator, RuntimeServiceId>
     From<&ServiceResources<Message, Settings, State, Operator, RuntimeServiceId>>
-    for ServiceHandle<Message, Settings, State, Operator>
+    for ServiceHandle<Message, Settings, State, Operator, RuntimeServiceId>
 where
     Settings: Clone,
     State: Clone,
@@ -230,5 +249,65 @@ where
             service_resources.state_handle.clone(),
             service_resources.lifecycle_handle.notifier().clone(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::services::state::StateOperator;
+
+    #[derive(Clone)]
+    struct TestState;
+
+    impl ServiceState for TestState {
+        type Settings = ();
+        type Error = std::convert::Infallible;
+
+        fn from_settings(_settings: &Self::Settings) -> Result<Self, Self::Error> {
+            panic!("settings fallback must not run after an operator error")
+        }
+    }
+
+    #[derive(Clone)]
+    struct FailingOperator;
+
+    #[async_trait]
+    impl StateOperator<()> for FailingOperator {
+        type State = TestState;
+        type LoadError = &'static str;
+
+        fn try_load(
+            _settings: &<Self::State as ServiceState>::Settings,
+        ) -> Result<Option<Self::State>, Self::LoadError> {
+            Err("recovery failed")
+        }
+
+        fn from_settings(
+            _settings: &<Self::State as ServiceState>::Settings,
+            _overwatch_handle: OverwatchHandle<()>,
+        ) -> Self {
+            Self
+        }
+
+        async fn run(&mut self, _state: Self::State) {}
+    }
+
+    #[test]
+    fn operator_load_error_does_not_fall_back_to_settings() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+        let resources = ServiceResources::<(), (), TestState, FailingOperator, ()>::new(
+            (),
+            OverwatchHandle::new(runtime.handle().clone(), sender),
+            1,
+        );
+
+        assert!(matches!(
+            resources.get_service_initial_state(),
+            Err(InitialStateError::Operator("recovery failed"))
+        ));
     }
 }

--- a/overwatch/src/services/runner/handle.rs
+++ b/overwatch/src/services/runner/handle.rs
@@ -2,16 +2,16 @@ use tokio::task::JoinHandle;
 
 use crate::services::service_handle::ServiceHandle;
 
-pub struct ServiceRunnerHandle<Message, Settings, State, StateOperator> {
-    service_handle: ServiceHandle<Message, Settings, State, StateOperator>,
+pub struct ServiceRunnerHandle<Message, Settings, State, StateOperator, RuntimeServiceId> {
+    service_handle: ServiceHandle<Message, Settings, State, StateOperator, RuntimeServiceId>,
     runner_join_handle: JoinHandle<()>,
 }
 
-impl<Message, Settings, State, StateOperator>
-    ServiceRunnerHandle<Message, Settings, State, StateOperator>
+impl<Message, Settings, State, StateOperator, RuntimeServiceId>
+    ServiceRunnerHandle<Message, Settings, State, StateOperator, RuntimeServiceId>
 {
     pub const fn new(
-        service_handle: ServiceHandle<Message, Settings, State, StateOperator>,
+        service_handle: ServiceHandle<Message, Settings, State, StateOperator, RuntimeServiceId>,
         runner_join_handle: JoinHandle<()>,
     ) -> Self {
         Self {
@@ -20,7 +20,9 @@ impl<Message, Settings, State, StateOperator>
         }
     }
 
-    pub const fn service_handle(&self) -> &ServiceHandle<Message, Settings, State, StateOperator> {
+    pub const fn service_handle(
+        &self,
+    ) -> &ServiceHandle<Message, Settings, State, StateOperator, RuntimeServiceId> {
         &self.service_handle
     }
 

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -193,12 +193,15 @@ where
                     if service_lifecycle_phase == ServiceLifecyclePhase::Started {
                         info!("Service is already running.");
                     } else {
-                        Self::handle_start::<Service>(
+                        if let Err(error) = Self::handle_start::<Service>(
                             &mut service_resources,
                             &mut service_task_handle,
                             &mut state_handle_task_handle,
                             task_names,
-                        );
+                        ) {
+                            error!(error, "Failed to start service.");
+                            continue;
+                        }
                         service_lifecycle_phase = ServiceLifecyclePhase::Started;
                     }
 
@@ -248,17 +251,15 @@ where
         service_task_handle: &mut Option<JoinHandle<()>>,
         state_handle_task_handle: &mut Option<JoinHandle<()>>,
         task_names: Option<TaskNames>,
-    ) where
+    ) -> Result<(), String>
+    where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
         StateOp: Clone,
     {
-        let initial_state = match service_resources.get_service_initial_state() {
-            Ok(initial_state) => initial_state,
-            Err(error) => {
-                panic!("Failed to create the initial state: {error}");
-            }
-        };
+        let initial_state = service_resources
+            .get_service_initial_state()
+            .map_err(|error| format!("Failed to create the initial state: {error}"))?;
 
         let service_resources_handle = service_resources.as_handle().unwrap_or_else(|error| {
             panic!("Failed to create the ServiceResourcesHandle: {error}");
@@ -286,6 +287,8 @@ where
             state_handle_task_handle,
             task_names,
         );
+
+        Ok(())
     }
 
     fn start_tasks<Service>(

--- a/overwatch/src/services/runner/service_runner.rs
+++ b/overwatch/src/services/runner/service_runner.rs
@@ -73,7 +73,7 @@ impl<Message, Settings, State, StateOp, RuntimeServiceId>
 where
     Settings: Clone,
     State: ServiceState<Settings = Settings> + Clone,
-    StateOp: StateOperator<State = State>,
+    StateOp: StateOperator<RuntimeServiceId, State = State>,
     RuntimeServiceId: Clone,
 {
     /// Creates a new `ServiceRunner`.
@@ -107,7 +107,8 @@ where
     Settings: Clone + 'static + Sync + Send,
     State: ServiceState<Settings = Settings> + Clone + Send + Sync + 'static,
     <State as ServiceState>::Error: Display,
-    StateOp: StateOperator<State = State> + Send + 'static,
+    StateOp: StateOperator<RuntimeServiceId, State = State> + Send + 'static,
+    <StateOp as StateOperator<RuntimeServiceId>>::LoadError: Display,
     RuntimeServiceId: 'static + Clone + Send,
 {
     /// Spawn the `ServiceRunner` loop. This will listen for lifecycle messages
@@ -118,7 +119,9 @@ where
     /// A [`ServiceRunnerHandle`] that contains the [`ServiceHandle`] and the
     /// [`JoinHandle`] of the [`ServiceRunner`] task.
     #[cfg(all(feature = "tokio-task-names", tokio_unstable))]
-    pub fn run<Service>(self) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
+    pub fn run<Service>(
+        self,
+    ) -> ServiceRunnerHandle<Message, Settings, State, StateOp, RuntimeServiceId>
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -142,7 +145,9 @@ where
     /// A [`ServiceRunnerHandle`] that contains the [`ServiceHandle`] and the
     /// [`JoinHandle`] of the [`ServiceRunner`] task.
     #[cfg(not(all(feature = "tokio-task-names", tokio_unstable)))]
-    pub fn run<Service>(self) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
+    pub fn run<Service>(
+        self,
+    ) -> ServiceRunnerHandle<Message, Settings, State, StateOp, RuntimeServiceId>
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -154,7 +159,7 @@ where
     fn spawn_runner<Service>(
         self,
         task_names: Option<TaskNames>,
-    ) -> ServiceRunnerHandle<Message, Settings, State, StateOp>
+    ) -> ServiceRunnerHandle<Message, Settings, State, StateOp, RuntimeServiceId>
     where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
@@ -251,7 +256,7 @@ where
         let initial_state = match service_resources.get_service_initial_state() {
             Ok(initial_state) => initial_state,
             Err(error) => {
-                panic!("Failed to create the initial state from settings: {error}");
+                panic!("Failed to create the initial state: {error}");
             }
         };
 
@@ -292,7 +297,7 @@ where
     ) where
         Service: ServiceCore<RuntimeServiceId, Settings = Settings, State = State, Message = Message>
             + 'static,
-        StateOp: StateOperator<State = State> + Clone,
+        StateOp: StateOperator<RuntimeServiceId, State = State> + Clone,
     {
         let runtime = service_resources.overwatch_handle().runtime().clone();
         let service_task = {

--- a/overwatch/src/services/service_handle.rs
+++ b/overwatch/src/services/service_handle.rs
@@ -14,7 +14,7 @@ use crate::services::{
 // is happening and it would get rid of the probably unnecessary Option and
 // cloning.
 #[derive(Clone)]
-pub struct ServiceHandle<Message, Settings, State, Operator> {
+pub struct ServiceHandle<Message, Settings, State, Operator, RuntimeServiceId> {
     /// Message channel relay
     ///
     /// It contains the channel if the service is running, otherwise it'll be
@@ -22,17 +22,19 @@ pub struct ServiceHandle<Message, Settings, State, Operator> {
     outbound_relay: OutboundRelay<Message>,
     settings_updater: SettingsUpdater<Settings>,
     status_watcher: StatusWatcher,
-    state_handle: StateHandle<State, Operator>,
+    state_handle: StateHandle<State, Operator, RuntimeServiceId>,
     lifecycle_notifier: LifecycleNotifier,
 }
 
-impl<Message, Settings, State, Operator> ServiceHandle<Message, Settings, State, Operator> {
+impl<Message, Settings, State, Operator, RuntimeServiceId>
+    ServiceHandle<Message, Settings, State, Operator, RuntimeServiceId>
+{
     /// Crate a new service handle.
     pub const fn new(
         outbound_relay: OutboundRelay<Message>,
         settings_updater: SettingsUpdater<Settings>,
         status_watcher: StatusWatcher,
-        state_handle: StateHandle<State, Operator>,
+        state_handle: StateHandle<State, Operator, RuntimeServiceId>,
         lifecycle_notifier: LifecycleNotifier,
     ) -> Self {
         Self {
@@ -62,7 +64,7 @@ impl<Message, Settings, State, Operator> ServiceHandle<Message, Settings, State,
     }
 
     /// Get the [`StateHandle`] for this service.
-    pub const fn state_handle(&self) -> &StateHandle<State, Operator> {
+    pub const fn state_handle(&self) -> &StateHandle<State, Operator, RuntimeServiceId> {
         &self.state_handle
     }
 

--- a/overwatch/src/services/state/handle.rs
+++ b/overwatch/src/services/state/handle.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use futures::FutureExt as _;
 use tokio_stream::StreamExt as _;
@@ -10,17 +10,18 @@ use crate::services::state::{StateOperator, StateUpdater, StateWatcher, Stream, 
 ///
 /// A [`StateHandle`] watches a stream of incoming states and triggers the
 /// attached operator handling method over it.
-pub struct StateHandle<State, Operator> {
+pub struct StateHandle<State, Operator, RuntimeServiceId> {
     watcher: StateWatcher<Option<State>>,
     operator: Operator,
     operator_fuse_receiver: fuse::Receiver,
+    runtime_service_id: PhantomData<fn() -> RuntimeServiceId>,
 }
 
 // Clone must be used carefully. It's very likely `Operator` will be a
 // `StateOperator`, which are likely behaving in as if they were singletons.
 // Clone is implemented manually because auto deriving introduces an unnecessary
 // Clone bound on T.
-impl<State, Operator> Clone for StateHandle<State, Operator>
+impl<State, Operator, RuntimeServiceId> Clone for StateHandle<State, Operator, RuntimeServiceId>
 where
     State: Clone,
     Operator: Clone,
@@ -30,11 +31,12 @@ where
             watcher: self.watcher.clone(),
             operator: self.operator.clone(),
             operator_fuse_receiver: self.operator_fuse_receiver.resubscribe(),
+            runtime_service_id: PhantomData,
         }
     }
 }
 
-impl<State, Operator> StateHandle<State, Operator> {
+impl<State, Operator, RuntimeServiceId> StateHandle<State, Operator, RuntimeServiceId> {
     pub const fn watcher(&self) -> &StateWatcher<Option<State>> {
         &self.watcher
     }
@@ -44,7 +46,7 @@ impl<State, Operator> StateHandle<State, Operator> {
     }
 }
 
-impl<State, Operator> StateHandle<State, Operator>
+impl<State, Operator, RuntimeServiceId> StateHandle<State, Operator, RuntimeServiceId>
 where
     State: Clone,
 {
@@ -64,16 +66,17 @@ where
                 watcher,
                 operator,
                 operator_fuse_receiver,
+                runtime_service_id: PhantomData,
             },
             updater,
         )
     }
 }
 
-impl<State, Operator> StateHandle<State, Operator>
+impl<State, Operator, RuntimeServiceId> StateHandle<State, Operator, RuntimeServiceId>
 where
     State: Clone + Send + Sync + 'static,
-    Operator: StateOperator<State = State>,
+    Operator: StateOperator<RuntimeServiceId, State = State>,
 {
     /// Wait for new state updates and run the operator handling method.
     pub async fn run(self) {
@@ -81,6 +84,7 @@ where
             watcher: StateWatcher { receiver },
             mut operator,
             mut operator_fuse_receiver,
+            ..
         } = self;
 
         let mut state_stream = Stream::new(receiver);
@@ -139,7 +143,7 @@ mod test {
     struct PanicOnGreaterThanTen;
 
     #[async_trait]
-    impl StateOperator for PanicOnGreaterThanTen {
+    impl StateOperator<()> for PanicOnGreaterThanTen {
         type State = UsizeCounter;
         type LoadError = Infallible;
 
@@ -149,7 +153,10 @@ mod test {
             Ok(None)
         }
 
-        fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
+        fn from_settings(
+            _settings: &<Self::State as ServiceState>::Settings,
+            _overwatch_handle: crate::overwatch::OverwatchHandle<()>,
+        ) -> Self {
             Self
         }
 
@@ -169,9 +176,9 @@ mod test {
     async fn state_stream_collects() {
         let (_operator_fuse_sender, operator_fuse_receiver) = fuse::channel();
         let initial_state = UsizeCounter::from_settings(&()).unwrap();
-        let settings = PanicOnGreaterThanTen::from_settings(&());
+        let settings = PanicOnGreaterThanTen;
         let (handle, updater): (
-            StateHandle<UsizeCounter, PanicOnGreaterThanTen>,
+            StateHandle<UsizeCounter, PanicOnGreaterThanTen, ()>,
             StateUpdater<Option<UsizeCounter>>,
         ) = StateHandle::new(settings, Some(initial_state), operator_fuse_receiver);
 

--- a/overwatch/src/services/state/operator.rs
+++ b/overwatch/src/services/state/operator.rs
@@ -2,14 +2,14 @@ use std::{convert::Infallible, marker::PhantomData, pin::Pin};
 
 use async_trait::async_trait;
 
-use crate::services::state::ServiceState;
+use crate::{overwatch::handle::OverwatchHandle, services::state::ServiceState};
 
 /// Performs an operation on a
 /// [`ServiceData::State`](crate::services::ServiceData::State) snapshot.
 ///
 /// A typical use case is to handle recovery: Saving and loading state.
 #[async_trait]
-pub trait StateOperator {
+pub trait StateOperator<RuntimeServiceId> {
     /// The type of state that the operator can handle.
     ///
     /// In the standard use case -
@@ -39,7 +39,10 @@ pub trait StateOperator {
 
     /// Operator initialization method. Can be implemented over some subset of
     /// settings.
-    fn from_settings(settings: &<Self::State as ServiceState>::Settings) -> Self;
+    fn from_settings(
+        settings: &<Self::State as ServiceState>::Settings,
+        overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self;
 
     /// Asynchronously perform an operation for a given state snapshot.
     async fn run(&mut self, state: Self::State);
@@ -66,7 +69,9 @@ impl<StateInput> Clone for NoOperator<StateInput> {
 }
 
 #[async_trait]
-impl<StateInput: ServiceState> StateOperator for NoOperator<StateInput> {
+impl<StateInput: ServiceState, RuntimeServiceId> StateOperator<RuntimeServiceId>
+    for NoOperator<StateInput>
+{
     type State = StateInput;
     type LoadError = Infallible;
 
@@ -76,7 +81,10 @@ impl<StateInput: ServiceState> StateOperator for NoOperator<StateInput> {
         Ok(None)
     }
 
-    fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(
+        _settings: &<Self::State as ServiceState>::Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
         Self(PhantomData)
     }
 

--- a/overwatch/tests/lifecycle.rs
+++ b/overwatch/tests/lifecycle.rs
@@ -44,7 +44,7 @@ struct LifecycleServiceStateOperator {
 }
 
 #[async_trait]
-impl StateOperator for LifecycleServiceStateOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for LifecycleServiceStateOperator {
     type State = LifecycleServiceState;
     type LoadError = String;
 
@@ -58,7 +58,10 @@ impl StateOperator for LifecycleServiceStateOperator {
             .map_err(|_| "Failed to lock the saved state mutex.".to_owned())
     }
 
-    fn from_settings(settings: &<Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(
+        settings: &<Self::State as ServiceState>::Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
         Self {
             saved_state: settings.saved_state,
             saved_sender: settings.saved_state_sender.clone(),

--- a/overwatch/tests/state_handling.rs
+++ b/overwatch/tests/state_handling.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, time::Duration};
 use async_trait::async_trait;
 use overwatch::{
     OpaqueServiceResourcesHandle, derive_services,
-    overwatch::OverwatchRunner,
+    overwatch::{OverwatchHandle, OverwatchRunner},
     services::{
         ServiceCore, ServiceData,
         state::{ServiceState, StateOperator},
@@ -50,7 +50,7 @@ impl ServiceState for CounterState {
 pub struct CounterStateOperator;
 
 #[async_trait]
-impl StateOperator for CounterStateOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for CounterStateOperator {
     type State = CounterState;
     type LoadError = Infallible;
 
@@ -60,7 +60,10 @@ impl StateOperator for CounterStateOperator {
         Ok(None)
     }
 
-    fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(
+        _settings: &<Self::State as ServiceState>::Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
         Self
     }
 

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -129,3 +129,27 @@ fn load_state_from_operator() {
     let service_message_2 = origin_receiver.recv().expect("Value was not sent");
     assert_eq!(service_message_2, "Service::run");
 }
+
+#[test]
+fn load_error_fails_service_start() {
+    let (origin_sender, origin_receiver) = mpsc::channel();
+    drop(origin_receiver);
+    let settings = TryLoadAppServiceSettings {
+        try_load: TryLoadSettings { origin_sender },
+    };
+
+    let app = OverwatchRunner::<TryLoadApp>::run(settings, None).unwrap();
+    let handle = app.handle().clone();
+
+    let start_result = handle.runtime().block_on(async {
+        tokio::time::timeout(Duration::from_secs(1), handle.start_service::<TryLoad>()).await
+    });
+
+    assert!(matches!(start_result, Ok(Err(_))));
+
+    handle
+        .runtime()
+        .block_on(handle.shutdown())
+        .expect("Overwatch to shut down successfully.");
+    app.blocking_wait_finished();
+}

--- a/overwatch/tests/try_load.rs
+++ b/overwatch/tests/try_load.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use overwatch::{
     DynError, OpaqueServiceResourcesHandle, derive_services,
-    overwatch::OverwatchRunner,
+    overwatch::{OverwatchHandle, OverwatchRunner},
     services::{
         ServiceCore, ServiceData,
         state::{ServiceState, StateOperator},
@@ -32,7 +32,7 @@ impl ServiceState for TryLoadState {
 struct TryLoadOperator;
 
 #[async_trait]
-impl StateOperator for TryLoadOperator {
+impl<RuntimeServiceId> StateOperator<RuntimeServiceId> for TryLoadOperator {
     type State = TryLoadState;
     type LoadError = SendError<String>;
 
@@ -45,7 +45,10 @@ impl StateOperator for TryLoadOperator {
         Ok(Some(Self::State {}))
     }
 
-    fn from_settings(_settings: &<Self::State as ServiceState>::Settings) -> Self {
+    fn from_settings(
+        _settings: &<Self::State as ServiceState>::Settings,
+        _overwatch_handle: OverwatchHandle<RuntimeServiceId>,
+    ) -> Self {
         Self {}
     }
 


### PR DESCRIPTION
State operators sometimes need to communicate with other Overwatch services. This updates from_settings to receive an OverwatchHandle, enabling cases such as saving recovery state through the storage service.

Recovery load errors are also propagated during startup. Previously, a failed load was treated the same as no saved state, causing the service to silently create fresh state from its settings. This could hide corrupted or unreadable recovery data and let the service start from the wrong state. 

Examples and tests are updated for the new API.