### PR TITLE
fix(handle): return RelayError instead of panicking when Overwatch is shut down

### DIFF
--- a/overwatch/src/overwatch/handle.rs
+++ b/overwatch/src/overwatch/handle.rs
@@ -75,15 +75,16 @@ where
         info!("Requesting relay with {}", RuntimeServiceId::SERVICE_ID);
         let (sender, receiver) = tokio::sync::oneshot::channel();
 
-        let Ok(()) = self
-            .send(OverwatchCommand::Relay(RelayCommand {
-                service_id: RuntimeServiceId::SERVICE_ID,
-                reply_channel: ReplyChannel::from(sender),
-            }))
-            .await
-        else {
-            unreachable!("Service relay should always be available");
-        };
+        // Sending fails once the Overwatch command receiver has been dropped,
+        // i.e. after Overwatch has started shutting down. That is reachable
+        // whenever a relay is requested concurrently with shutdown, so report it
+        // as an error rather than panicking.
+        self.send(OverwatchCommand::Relay(RelayCommand {
+            service_id: RuntimeServiceId::SERVICE_ID,
+            reply_channel: ReplyChannel::from(sender),
+        }))
+        .await
+        .map_err(|_| RelayError::Send)?;
         let message = receiver
             .await
             .map_err(|e| RelayError::Receiver(Box::new(e)))?;

--- a/overwatch/tests/relay_after_shutdown.rs
+++ b/overwatch/tests/relay_after_shutdown.rs
@@ -1,0 +1,74 @@
+//! Regression test for requesting a relay once Overwatch has shut down.
+//!
+//! `OverwatchHandle::relay` sends a command over an mpsc channel whose receiver
+//! lives in the Overwatch runner. Once the runner has finished, that receiver is
+//! gone and the send fails. That path used to hit an `unreachable!`, so a relay
+//! requested concurrently with shutdown panicked instead of returning the
+//! `RelayError` the function already advertises.
+
+use async_trait::async_trait;
+use overwatch::{
+    DynError, OpaqueServiceResourcesHandle,
+    overwatch::OverwatchRunner,
+    services::{
+        ServiceCore, ServiceData,
+        relay::RelayError,
+        state::{NoOperator, NoState},
+    },
+};
+use overwatch_derive::derive_services;
+
+pub struct IdleService;
+
+impl ServiceData for IdleService {
+    type Settings = ();
+    type State = NoState<Self::Settings>;
+    type StateOperator = NoOperator<Self::State>;
+    type Message = ();
+}
+
+#[async_trait]
+impl ServiceCore<RuntimeServiceId> for IdleService {
+    fn init(
+        _service_resources_handle: OpaqueServiceResourcesHandle<Self, RuntimeServiceId>,
+        _initial_state: Self::State,
+    ) -> Result<Self, DynError> {
+        Ok(Self)
+    }
+
+    async fn run(self) -> Result<(), DynError> {
+        Ok(())
+    }
+}
+
+#[derive_services]
+struct App {
+    idle_service: IdleService,
+}
+
+#[tokio::test]
+async fn relay_after_shutdown_returns_error_instead_of_panicking() {
+    let runtime_handle = tokio::runtime::Handle::current();
+    let settings = AppServiceSettings { idle_service: () };
+    let app = OverwatchRunner::<App>::run(settings, Some(runtime_handle))
+        .expect("OverwatchRunner should start.");
+
+    // Keep a handle alive past the runner, exactly as a long-lived caller
+    // (an HTTP handler, an FFI binding) would hold one.
+    let handle = app.handle().clone();
+
+    handle
+        .shutdown()
+        .await
+        .expect("Overwatch should shut down successfully.");
+    app.wait_finished().await;
+
+    // The command receiver is dropped by now, so the send inside `relay` fails.
+    // This must surface as an error rather than panicking.
+    let result = handle.relay::<IdleService>().await;
+
+    assert!(
+        matches!(result, Err(RelayError::Send)),
+        "relay after shutdown should return RelayError::Send"
+    );
+}


### PR DESCRIPTION
## Problem

`OverwatchHandle::relay` panics if it is called once Overwatch has started shutting down.

It sends a `RelayCommand` over the Overwatch command channel, and routes a send failure into an `unreachable!`:

```rust
let Ok(()) = self
    .send(OverwatchCommand::Relay(RelayCommand { .. }))
    .await
else {
    unreachable!("Service relay should always be available");
};
```

That branch is very much reachable. `send` is a `tokio::sync::mpsc` send, which returns `Err` as soon as its receiver is dropped — and the receiver lives in the Overwatch runner, so it goes away the moment the runner finishes. Any relay requested concurrently with, or after, shutdown lands on the `unreachable!` and panics.

The function already returns `Result<_, RelayError>` and its own docs say:

> **Errors:** If the relay cannot be created, or if the service is not available.

So the error path already existed — it just wasn't used.

## Why it matters

For an in-process caller this is a panic in one task. For a host that embeds Overwatch **through FFI it is fatal to the whole process**: the panic unwinds out of an `extern "C"` boundary (abort), or gets caught by a `process::exit` panic hook.

We hit exactly this downstream. A Logos Basecamp node polls a consensus query every 2 s; when a poll raced node shutdown, this `unreachable!` fired and took down the host process with SIGABRT:

```
panicked at .../overwatch/src/overwatch/handle.rs:85:13:
internal error: entered unreachable code: Service relay should always be available
```

## Change

Map the send failure to the existing `RelayError::Send` variant instead of panicking:

```rust
self.send(OverwatchCommand::Relay(RelayCommand { .. }))
    .await
    .map_err(|_| RelayError::Send)?;
```

Non-breaking: the signature and documented contract are unchanged; a path that used to abort now returns the error it always promised.

## Regression test

`overwatch/tests/relay_after_shutdown.rs` starts an app, shuts Overwatch down, waits for the runner to finish, then requests a relay.

- **Without** this change it fails, reproducing the production panic verbatim: `entered unreachable code: Service relay should always be available` at `handle.rs:85`.
- **With** it, the call returns `Err(RelayError::Send)`.

## Not included

`status_watcher` has the same defect twice — the `unreachable!` at `handle.rs:118` and the `receiver.await` `unwrap_or_else(|_| panic!(..))` right after it. Fixing those properly means returning a `Result` where it currently returns a bare `StatusWatcher`, which is a **breaking** signature change, so I left it out of this PR. Happy to follow up if you want it.

The `message.downcast::<..>()` `unreachable!` is left alone too: that one really is a static type invariant.

## Verification

Toolchain 1.96.0, per `rust-toolchain.toml`:

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — all unit/integration tests pass, including the new one
- The 8 README doctest failures are **pre-existing on `main`** (verified by stashing this change: 0 passed / 8 failed both with and without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)